### PR TITLE
Use inviter link for Slack in architecture doc

### DIFF
--- a/docs/architecture/00_architecture.md
+++ b/docs/architecture/00_architecture.md
@@ -67,7 +67,7 @@ Visit our [GitHub Releases page](https://github.com/llm-d/llm-d-deployer/release
 - See [our project overview](https://github.com/llm-d/llm-d/blob/dev/PROJECT.md) for more details on our development process and governance.
 
 ### Connect
-- We use Slack to discuss development across organizations. Please join [here](https://inviter.co/llm-d-slack)
+- We use Slack to discuss development across organizations. Please join via [this inviter link](https://inviter.co/llm-d-slack) and access the workspace [here](https://llm-d.slack.com).
 - We host a weekly standup for contributors on Wednesdays at 1230pm ET. Please join: [Meeting Details](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NG9yZ3AyYTN0N3VlaW01b21xbWV2c21uNjRfMjAyNTA1MjhUMTYzMDAwWiByb2JzaGF3QHJlZGhhdC5jb20&tmsrc=robshaw%40redhat.com&scp=ALL)
 - We use Google Groups to share architecture diagrams and other content. Please join: [Google Group](https://groups.google.com/g/llm-d-contributors)
 

--- a/docs/architecture/00_architecture.md
+++ b/docs/architecture/00_architecture.md
@@ -67,7 +67,7 @@ Visit our [GitHub Releases page](https://github.com/llm-d/llm-d-deployer/release
 - See [our project overview](https://github.com/llm-d/llm-d/blob/dev/PROJECT.md) for more details on our development process and governance.
 
 ### Connect
-- We use Slack to discuss development across organizations. Please join: [ https://llm-d.slack.com](https://llm-d.slack.com)
+- We use Slack to discuss development across organizations. Please join [here](https://inviter.co/llm-d-slack)
 - We host a weekly standup for contributors on Wednesdays at 1230pm ET. Please join: [Meeting Details](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NG9yZ3AyYTN0N3VlaW01b21xbWV2c21uNjRfMjAyNTA1MjhUMTYzMDAwWiByb2JzaGF3QHJlZGhhdC5jb20&tmsrc=robshaw%40redhat.com&scp=ALL)
 - We use Google Groups to share architecture diagrams and other content. Please join: [Google Group](https://groups.google.com/g/llm-d-contributors)
 


### PR DESCRIPTION
The existing link is only usable for existing members. 