### PR TITLE
Update the contributing docs to include calendar and Google Group

### DIFF
--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -64,11 +64,11 @@ The process for accepting code contributions is as follows:
 
 All pull requests will be reviewed by the lead core Maintainer. Feedback will be provided, and you may be asked to make revisions. The project leads will ultimately decide whether to merge the pull request based on its alignment with the project's vision, code quality, and overall impact.
 
-## Community and Communication 
+## Community and Communication
 
-* **Developer Slack:** [Join our developer Slack workspace](https://inviter.co/llm-d-slack) to connect with the core maintainers and other contributors, ask questions, and participate in discussions. 
-* **Weekly Meetings:** Project updates, ongoing work discussions, and Q&A will be covered in our weekly project meeting. Details regarding the day, time, and meeting link will be shared soon!
-* **Social Media:** Follow us on social media for the latest news, announcements, and updates: 
+* **Developer Slack:** [Join our developer Slack workspace](https://inviter.co/llm-d-slack) to connect with the core maintainers and other contributors, ask questions, and participate in discussions.
+* **Weekly Meetings:** Project updates, ongoing work discussions, and Q&A will be covered in our weekly project meeting every Wednesday at 12:30 PM ET. Please join by [adding the shared calendar](https://calendar.google.com/calendar/u/0?cid=NzA4ZWNlZDY0NDBjYjBkYzA3NjdlZTNhZTk2NWQ2ZTc1Y2U5NTZlMzA5MzhmYTAyZmQ3ZmU1MDJjMDBhNTRiNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t). You can also [join our Google Group](https://groups.google.com/g/llm-d-contributors) for access to shared diagrams and other content.
+* **Social Media:** Follow us on social media for the latest news, announcements, and updates:
   * **X:** [https://x.com/\_llm_d\_](https://x.com/_llm_d_)
   * **LinkedIn:** [https://linkedin.com/company/llm-d ](https://linkedin.com/company/llm-d)
   * **Reddit:** [https://www.reddit.com/r/llm_d/](https://www.reddit.com/r/llm_d/)


### PR DESCRIPTION
Noticed the [README](https://groups.google.com/g/llm-d-contributors) in llm-d had the meeting link but not the website. Happy to change wording or format!