### PR TITLE
Add a VimeoEmbed component to embed public or private vimeo videos

### DIFF
--- a/docs/architecture/00_architecture.mdx
+++ b/docs/architecture/00_architecture.mdx
@@ -9,6 +9,10 @@ With `llm-d`, users can operationalize GenAI deployments with a modular solution
 
 Built by leaders in the Kubernetes and vLLM projects, `llm-d` is a community-driven, Apache-2 licensed project with an open development model.
 
+import VimeoEmbed from '@site/src/components/VimeoEmbed';
+
+<VimeoEmbed videoId="1084693051" hash="f92f0d6b1d" />
+
 ##  Architecture
 
 `llm-d` adopts a layered architecture on top of industry-standard open technologies: vLLM, Kubernetes, and Inference Gateway.
@@ -16,7 +20,6 @@ Built by leaders in the Kubernetes and vLLM projects, `llm-d` is a community-dri
 
 ![llm-d Architecture](../assets/images/llm-d-arch-simplified.svg)
     
-
 
 Key features of `llm-d` include:
 

--- a/src/components/VimeoEmbed.js
+++ b/src/components/VimeoEmbed.js
@@ -1,0 +1,52 @@
+import React from 'react';
+
+const VimeoEmbed = ({ 
+  videoId, 
+  hash, 
+  width = '100%', 
+  height = '360',
+  responsive = true 
+}) => {
+  // Construct the URL based on whether it's a private or public video
+  const src = hash 
+    ? `https://player.vimeo.com/video/${videoId}?h=${hash}` // Private video with hash
+    : `https://player.vimeo.com/video/${videoId}`; // Public video
+  
+  if (responsive) {
+    return (
+      <div style={{ 
+        position: 'relative', 
+        paddingBottom: '56.25%', 
+        height: 0,
+        overflow: 'hidden'
+      }}>
+        <iframe
+          src={src}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%'
+          }}
+          frameBorder="0"
+          allow="autoplay; fullscreen; picture-in-picture"
+          allowFullScreen
+        />
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      src={src}
+      width={width}
+      height={height}
+      frameBorder="0"
+      allow="autoplay; fullscreen; picture-in-picture"
+      allowFullScreen
+    />
+  );
+};
+
+export default VimeoEmbed;


### PR DESCRIPTION
In looking at how to embed videos on docusaurus, I think the issue that might have previously happened was that the vimeo video is "public but only with the link".  This means that the URL includes the video ID but also a hash/key that needs to be included in the request.  

This code will work also if you exclude the `hash` which is needed when any videos are made "public".  

@KPRoche Check this out and let me know what you think.  This is mostly a proof of concept, I'm not entirely sure where we should/could put the video and if the component is in the right place.  