### PR TITLE
Update branch for llm-d repository from 'dev' to 'main' for docs sync

### DIFF
--- a/remote-content/remote-sources/component-configs.js
+++ b/remote-content/remote-sources/component-configs.js
@@ -14,7 +14,7 @@ export const COMMON_REPO_CONFIGS = {
   'llm-d-main': {
     name: 'llm-d',
     org: 'llm-d',
-    branch: 'dev',
+    branch: 'main',
     description: 'Main llm-d repository with core architecture and documentation'
   },
   'llm-d-infra': {

--- a/remote-content/remote-sources/guide/guide-generator.js
+++ b/remote-content/remote-sources/guide/guide-generator.js
@@ -18,12 +18,20 @@ const contentTransform = createStandardTransform('llm-d');
  */
 const SPECIAL_GUIDES = {
   'prerequisites': {
-    sourceFile: 'guides/QUICKSTART.md',
+    sourceFile: 'guides/prereq/infrastructure/README.md',
     title: 'Prerequisites',
     description: 'Prerequisites for running the llm-d QuickStart',
     sidebarLabel: 'Prerequisites',
     sidebarPosition: 1,
     outputFile: 'prerequisites.md'
+  },
+  'quickstart': {
+    sourceFile: 'guides/QUICKSTART.md',
+    title: 'QuickStart',
+    description: 'QuickStart guide for llm-d',
+    sidebarLabel: 'QuickStart',
+    sidebarPosition: 2,
+    outputFile: 'quickstart.md'
   },
   'guide': {
     sourceFile: 'guides/README.md',
@@ -46,31 +54,31 @@ const DYNAMIC_GUIDES = [
     dirName: 'inference-scheduling',
     title: 'Intelligent Inference Scheduling',
     description: 'Well-lit path for intelligent inference scheduling with load balancing',
-    sidebarPosition: 2
+    sidebarPosition: 3
   },
   {
     dirName: 'pd-disaggregation', 
     title: 'Prefill/Decode Disaggregation',
     description: 'Well-lit path for separating prefill and decode operations',
-    sidebarPosition: 3
+    sidebarPosition: 4
   },
   {
     dirName: 'precise-prefix-cache-aware',
     title: 'Precise Prefix Cache Aware Routing',
     description: 'Feature guide for precise prefix cache aware routing',
-    sidebarPosition: 4
+    sidebarPosition: 5
   },
   {
     dirName: 'simulated-accelerators',
     title: 'Accelerator Simulation',
     description: 'Feature guide for llm-d accelerator simulation',
-    sidebarPosition: 5
+    sidebarPosition: 6
   },
   {
     dirName: 'wide-ep-lws',
     title: 'Wide Expert Parallelism with LeaderWorkerSet',
     description: 'Well-lit path for wide expert parallelism using LeaderWorkerSet',
-    sidebarPosition: 6
+    sidebarPosition: 7
   }
 ];
 

--- a/remote-content/remote-sources/guide/guide-generator.js
+++ b/remote-content/remote-sources/guide/guide-generator.js
@@ -3,6 +3,15 @@
  * 
  * Automatically discovers and generates guide pages from the llm-d repository's guides directory.
  * This replaces the individual guide files and consolidates all guide content management.
+ * 
+ * Future Versioning Support:
+ * - When implementing Docusaurus versioning, this generator can be extended to:
+ *   1. Accept version/branch parameters in the configuration
+ *   2. Generate versioned outDir paths (e.g., 'docs/1.0/guide/Installation')
+ *   3. Update sourceBaseUrl to point to specific tags/releases
+ *   4. Maintain separate guide configurations per version
+ * - The internal link mapping in repo-transforms.js will automatically handle
+ *   version-aware routing between guides within the same version
  */
 
 import { createContentWithSource, createStandardTransform } from '../utils.js';

--- a/remote-content/remote-sources/repo-transforms.js
+++ b/remote-content/remote-sources/repo-transforms.js
@@ -11,6 +11,10 @@
  * Mapping of GitHub guide paths to local documentation paths
  * This allows internal links between synced guides to stay within the site
  * 
+ * IMPORTANT: Only files listed in this mapping will have their GitHub URLs
+ * transformed to local paths. All other files (even in guides/) will remain
+ * as GitHub links for safety and precision.
+ * 
  * Future versioning support:
  * - When versioning is enabled, paths will be prefixed with version (e.g., /docs/1.0/guide)
  * - The getInternalGuidePath function will handle version detection automatically
@@ -59,15 +63,18 @@ function getVersionedPath(basePath, branch) {
 /**
  * Check if a GitHub URL points to a synced guide and return the local path
  * Supports future versioning by detecting branch/tag from URL
+ * ONLY transforms links to files that are actually synced (exist in INTERNAL_GUIDE_MAPPINGS)
  */
 function getInternalGuidePath(githubUrl) {
-  // Match GitHub blob URLs for the llm-d repo guides with any branch/tag
-  // Handles branch names with slashes (e.g., feature/branch-name, legacy/v0.9)
-  const match = githubUrl.match(/https:\/\/github\.com\/llm-d\/llm-d\/blob\/(.+?)\/(guides\/.+\.md)$/);
+  // Match GitHub blob URLs for the llm-d repo with any branch/tag
+  // More permissive regex to capture the full path, then check if it's a synced guide
+  const match = githubUrl.match(/https:\/\/github\.com\/llm-d\/llm-d\/blob\/(.+?)\/(.+\.md)$/);
   if (match) {
     const branch = match[1];
-    const guidePath = match[2];
-    const basePath = INTERNAL_GUIDE_MAPPINGS[guidePath];
+    const filePath = match[2];
+    
+    // CRITICAL: Only transform if this exact file path is in our synced mappings
+    const basePath = INTERNAL_GUIDE_MAPPINGS[filePath];
     
     if (basePath) {
       return getVersionedPath(basePath, branch);

--- a/remote-content/remote-sources/repo-transforms.js
+++ b/remote-content/remote-sources/repo-transforms.js
@@ -3,7 +3,78 @@
  * 
  * Unified transformation that links all relative references back to the source repository.
  * This ensures consistency across all content and prevents broken links.
+ * 
+ * Special handling for internal guide links to keep them within the documentation site.
  */
+
+/**
+ * Mapping of GitHub guide paths to local documentation paths
+ * This allows internal links between synced guides to stay within the site
+ * 
+ * Future versioning support:
+ * - When versioning is enabled, paths will be prefixed with version (e.g., /docs/1.0/guide)
+ * - The getInternalGuidePath function will handle version detection automatically
+ * - Current paths work for both current docs and as base paths for future versions
+ */
+const INTERNAL_GUIDE_MAPPINGS = {
+  // Main guides
+  'guides/README.md': '/docs/guide',
+  'guides/QUICKSTART.md': '/docs/guide/Installation/quickstart',
+  'guides/prereq/infrastructure/README.md': '/docs/guide/Installation/prerequisites',
+  
+  // Dynamic guides (Installation section)
+  'guides/inference-scheduling/README.md': '/docs/guide/Installation/inference-scheduling',
+  'guides/pd-disaggregation/README.md': '/docs/guide/Installation/pd-disaggregation',
+  'guides/precise-prefix-cache-aware/README.md': '/docs/guide/Installation/precise-prefix-cache-aware',
+  'guides/simulated-accelerators/README.md': '/docs/guide/Installation/simulated-accelerators',
+  'guides/wide-ep-lws/README.md': '/docs/guide/Installation/wide-ep-lws'
+};
+
+/**
+ * Generate versioned documentation path based on branch/tag
+ * Future-ready for Docusaurus versioning best practices
+ */
+function getVersionedPath(basePath, branch) {
+  // Current behavior: main branch uses current docs paths
+  if (branch === 'main') {
+    return basePath;
+  }
+  
+  // Future versioning logic (when implemented):
+  // - Release tags (e.g., 'v1.0.0', 'v2.1.0') -> /docs/1.0/... or /docs/2.1/...
+  // - Development branches -> /docs/next/...
+  // - Legacy branches -> /docs/legacy/...
+  
+  // Version detection patterns for future use:
+  const versionMatch = branch.match(/^v?(\d+\.\d+)(?:\.\d+)?$/); // e.g., v1.0.0 -> 1.0
+  if (versionMatch) {
+    const version = versionMatch[1];
+    return basePath.replace('/docs/', `/docs/${version}/`);
+  }
+  
+  // Default: treat as current version for unknown branches
+  return basePath;
+}
+
+/**
+ * Check if a GitHub URL points to a synced guide and return the local path
+ * Supports future versioning by detecting branch/tag from URL
+ */
+function getInternalGuidePath(githubUrl) {
+  // Match GitHub blob URLs for the llm-d repo guides with any branch/tag
+  // Handles branch names with slashes (e.g., feature/branch-name, legacy/v0.9)
+  const match = githubUrl.match(/https:\/\/github\.com\/llm-d\/llm-d\/blob\/(.+?)\/(guides\/.+\.md)$/);
+  if (match) {
+    const branch = match[1];
+    const guidePath = match[2];
+    const basePath = INTERNAL_GUIDE_MAPPINGS[guidePath];
+    
+    if (basePath) {
+      return getVersionedPath(basePath, branch);
+    }
+  }
+  return null;
+}
 
 /**
  * Apply essential MDX compatibility fixes and content transformations
@@ -111,7 +182,8 @@ function fixImages(content, repoUrl, branch, sourceDir = '') {
 
 /**
  * Unified transform function for all repositories
- * All relative links point back to the source repository on GitHub
+ * All relative links point back to the source repository on GitHub, except for
+ * internal guide links which are redirected to local documentation pages
  */
 export function transformRepo(content, { repoUrl, branch, sourcePath = '' }) {
   // Get the directory of the source file to resolve relative paths correctly
@@ -122,11 +194,25 @@ export function transformRepo(content, { repoUrl, branch, sourcePath = '' }) {
     .replace(/\]\((?!http|https|#|mailto:)([^)]+)\)/g, (match, path) => {
       const cleanPath = path.replace(/^\]\(/, '');
       const resolvedUrl = resolvePath(cleanPath, sourceDir, repoUrl, branch);
+      
+      // Check if this resolved GitHub URL should be an internal link instead
+      const internalPath = getInternalGuidePath(resolvedUrl);
+      if (internalPath) {
+        return `](${internalPath})`;
+      }
+      
       return `](${resolvedUrl})`;
     })
     // All relative links go to source repository (reference format)
     .replace(/^\[([^\]]+)\]:(?!http|https|#|mailto:)([^\s]+)/gm, (match, label, path) => {
       const resolvedUrl = resolvePath(path, sourceDir, repoUrl, branch);
+      
+      // Check if this resolved GitHub URL should be an internal link instead
+      const internalPath = getInternalGuidePath(resolvedUrl);
+      if (internalPath) {
+        return `[${label}]:${internalPath}`;
+      }
+      
       return `[${label}]:${resolvedUrl}`;
     });
 }

--- a/src/components/Install/index.js
+++ b/src/components/Install/index.js
@@ -22,7 +22,7 @@ export default function Install() {
               alt="1. "
               src={require('/docs/assets/counting-01.png').default}
               ></img>
-            <a className="link" href="docs/guide/Installation/prerequisites#compute">
+            <a className="link" href="docs/guide/Installation/prerequisites">
               Check the Prerequisites
             </a>
           </h3>
@@ -34,7 +34,7 @@ export default function Install() {
               alt="2. "
               src={require('/docs/assets/counting-02.png').default}
               ></img>
-            <a className="link" href="docs/guide/Installation/prerequisites#examples">
+            <a className="link" href="docs/guide/Installation/quickstart">
               Run the Quickstart
             </a>
           </h3>


### PR DESCRIPTION
The llm-d/llm-d repo now tracks off main so we'll sync against that.  

Now that guides exist in that repo we'll likely setup some versioning so that we're always showing by default the latest stable release of the guides, but also support seeing the latest.  Near term just trying to get the latest guides on the site. 