### PR TITLE
Fix mermaid rendering in repo transforms

### DIFF
--- a/remote-content/remote-sources/repo-transforms.js
+++ b/remote-content/remote-sources/repo-transforms.js
@@ -79,9 +79,13 @@ function applyBasicMdxFixes(content) {
       
       return `:::${docusaurusType}\n${cleanContent}\n:::\n`;
     })
-    // Fix HTML comments for MDX compatibility
-    .replace(/<!--\s*/g, '{/* ')
-    .replace(/\s*-->/g, ' */}')
+    // Fix HTML comments for MDX compatibility (without breaking Mermaid arrows)
+    .replace(/<!--([\s\S]*?)-->/g, (_match, comment) => {
+      const normalized = comment
+        .replace(/^\s*/, ' ')
+        .replace(/\s*$/, ' ');
+      return `{/*${normalized}*/}`;
+    })
     // Fix HTML tags for MDX compatibility
     .replace(/<br>/g, '<br />')
     .replace(/<br([^/>]*?)>/g, '<br$1 />')


### PR DESCRIPTION
Root cause was in `remote-content/remote-sources/repo-transforms.js`: the HTML comment cleanup blindly replaced every -->, so Mermaid arrows like A-->B turned into */} during the remote-content sync.

The reason we have that transform in the first place raw `<!-- ... -->` comments are valid in Markdown but not in MDX. When Docusaurus runs MDX, those comments are treated as JSX and cause build-time syntax errors.

Updated the transform to rewrite only actual HTML comments, leaving Mermaid syntax intact. This prevents the bad replacement and keeps diagrams renderable.

<img width="915" height="272" alt="Screenshot 2025-11-13 at 10 24 27 AM" src="https://github.com/user-attachments/assets/6467ff8c-ab19-4645-a004-e6893fa10bb0" />

