### PR TITLE
Improve code block contrast in light mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -297,8 +297,8 @@ const config = {
         ],
       },
       prism: {
-        theme: prismThemes.vsLight,
-        darkTheme: prismThemes.vsDark,
+        theme: prismThemes.github,
+        darkTheme: prismThemes.dracula,
         additionalLanguages: ['yaml'],
       },
     }),

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -32,6 +32,10 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-font-family-base: "Red Hat Display", Arial, Helvetica, sans-serif;
   --ifm-font-family-monospace: "Red Hat Mono", "Courier New", monospace;
+  /* Light mode code block styling for better contrast */
+  --ifm-pre-background: #f6f8fa;
+  --ifm-pre-color: #24292f;
+  --ifm-code-background: #f6f8fa;
   background-color: white;
 }
 
@@ -45,7 +49,6 @@
   --ifm-color-primary-lighter: #e3bbe3;
   --ifm-color-primary-lightest: #f3e1f3;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
-  --ifm-pre-background: #7f317f;
   background-color: #262626;
 }
 
@@ -534,4 +537,40 @@ img.llm-d-logo {
 
 [data-theme="dark"] .language-yaml .prism-code .token.boolean {
   color: #79c0ff !important; /* Consistent light blue */
+}
+
+/* Improve light mode code block visibility with border and shadow - LIGHT MODE ONLY */
+html:not([data-theme="dark"]) pre {
+  border: 1px solid #d0d7de;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+/* Override Prism inline styles for better contrast - LIGHT MODE ONLY */
+html:not([data-theme="dark"]) .prism-code {
+  background-color: #f6f8fa !important;
+}
+
+html:not([data-theme="dark"]) .codeBlockContainer_Ckt0 {
+  --prism-background-color: #f6f8fa !important;
+}
+
+html:not([data-theme="dark"]) pre.prism-code {
+  background-color: #f6f8fa !important;
+}
+
+/* Dark mode code block text - use original blue color from vsDark theme */
+[data-theme="dark"] .prism-code {
+  --prism-color: #9CDCFE !important;
+}
+
+[data-theme="dark"] pre.prism-code {
+  color: #9CDCFE !important;
+}
+
+[data-theme="dark"] .token-line {
+  color: #9CDCFE !important;
+}
+
+[data-theme="dark"] .token.plain {
+  color: #9CDCFE !important;
 }


### PR DESCRIPTION
Light mode code blocks were hard to read with the pure white background blending into the page. Switched to the GitHub Prism theme and added a subtle gray background with a border so they actually stand out now.

Also tweaked dark mode to use Dracula theme while keeping the original light blue text color everyone's used to. I had ran into problems to dark mode when changing the light mode so i just changed the theme to get around the issues. 

Changes:
- Light mode: gray background (#f6f8fa) instead of white
- Dark mode: Dracula theme with original blue text (#9CDCFE)
- Added proper CSS scoping so the themes don't mess with each other

Before:
<img width="944" height="179" alt="Screenshot 2025-11-19 at 12 12 04 PM" src="https://github.com/user-attachments/assets/bd3e9887-0fd2-466f-ab02-212e7f206fcd" />
After:
<img width="932" height="175" alt="Screenshot 2025-11-19 at 12 14 21 PM" src="https://github.com/user-attachments/assets/6d5822bb-febc-42a4-a669-6e82e1480afd" />


Before:
<img width="955" height="147" alt="Screenshot 2025-11-19 at 12 12 00 PM" src="https://github.com/user-attachments/assets/6eafa6b4-5e5d-48c5-a51c-370e63ebc4a4" />
After:
<img width="960" height="227" alt="Screenshot 2025-11-19 at 12 14 17 PM" src="https://github.com/user-attachments/assets/969818d9-0d11-412c-8037-f9a46cbdefd9" />
