### PR TITLE
feat: Strip markdownlint directives in MDX content transformation

### DIFF
--- a/remote-content/remote-sources/repo-transforms.js
+++ b/remote-content/remote-sources/repo-transforms.js
@@ -61,6 +61,8 @@ function getInternalGuidePath(githubUrl) {
  */
 function applyBasicMdxFixes(content) {
   return content
+    // Strip markdownlint directives at the top of the file (they break MDX import placement)
+    .replace(/^<!--\s*markdownlint-disable[^>]*-->\s*\n?/i, '')
     // Convert GitHub-style callouts to Docusaurus admonitions
     .replace(/^> \[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*\n((?:> .*\n?)*)/gm, (match, type, content) => {
       // Map GitHub callout types to Docusaurus admonition types


### PR DESCRIPTION
Added functionality to remove markdownlint directives from the top of MDX files to prevent issues with import placement during content transformation.  Leaving these in will break the mdx generation, and they are not needed on the website side. 

This needs to be merged before https://github.com/llm-d/llm-d/pull/452 get's deployed in the next release of llm-d.  