### PR TITLE
Fix a bug where it failed to add a new line in the end

### DIFF
--- a/remote-content/remote-sources/utils.js
+++ b/remote-content/remote-sources/utils.js
@@ -152,7 +152,7 @@ sidebar_position: ${sidebarPosition}
   const transformedContent = contentTransform ? contentTransform(content, filename) : content;
   
   // Ensure content ends with a newline before adding the callout
-  const contentWithNewline = transformedContent.endsWith('\n') ? transformedContent : transformedContent + '\n';
+  const contentWithNewline = transformedContent + '\n';
   
   return {
     filename: newFilename,


### PR DESCRIPTION
Not sure why it didn't work before. But I think simply adding a new line doesn't hurt...

Without this some pages failed to render with the `import Tabs from '@theme/Tabs';` moved to the end.

@petecheslock 