### PR TITLE
Add tabbed content support in documentation and implement conversion to Docusaurus Tabs components

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,19 +171,14 @@ When writing documentation in source repositories (like llm-d/llm-d) that will b
 
 <!-- TABS:START -->
 <!-- TAB:GKE (H200):default -->
-```bash
 kubectl apply -k ./manifests/modelserver/gke -n ${NAMESPACE}
-```
 
 <!-- TAB:GKE (B200) -->
-```bash
 kubectl apply -k ./manifests/modelserver/gke-a4 -n ${NAMESPACE}
-```
 
 <!-- TAB:CoreWeave -->
-```bash
 kubectl apply -k ./manifests/modelserver/coreweave -n ${NAMESPACE}
-```
+
 <!-- TABS:END -->
 ```
 
@@ -197,6 +192,32 @@ kubectl apply -k ./manifests/modelserver/coreweave -n ${NAMESPACE}
 
 **Result on Docusaurus:**
 The content will automatically be transformed with the proper Tabs imports and components, creating an interactive tabbed interface.
+
+### GitHub Callouts Support
+
+The transformation system also automatically converts GitHub-style callouts to Docusaurus admonitions:
+
+```markdown
+> [!NOTE]
+> This is a note
+
+> [!TIP]
+> This is a tip
+
+> [!IMPORTANT]
+> This is important
+
+> [!WARNING]
+> This is a warning
+
+> [!CAUTION]
+> This is dangerous
+
+> [!REQUIREMENTS]
+> These are requirements
+```
+
+These will be automatically converted to the appropriate Docusaurus `:::note`, `:::tip`, `:::info`, `:::warning`, and `:::danger` admonitions during the build.
 
 ### Troubleshooting
 


### PR DESCRIPTION
- Introduced a new section in README.md detailing how to create tabbed content using HTML comment markers for Docusaurus.
- Implemented a function in repo-transforms.js to convert GitHub-style tab markers into Docusaurus Tabs components, enhancing documentation interactivity.
### Creating Tabs in Remote Content

When writing documentation in source repositories (like llm-d/llm-d) that will be synced to this Docusaurus site, you can create tabbed content using HTML comment markers. These are invisible in GitHub but will be transformed into Docusaurus tabs during the build.

**In your GitHub README:**
```markdown
### Deploy Model Servers

<!-- TABS:START -->
<!-- TAB:GKE (H200):default -->

kubectl apply -k ./manifests/modelserver/gke -n ${NAMESPACE}

<!-- TAB:GKE (B200) -->

kubectl apply -k ./manifests/modelserver/gke-a4 -n ${NAMESPACE}

<!-- TAB:CoreWeave -->
kubectl apply -k ./manifests/modelserver/coreweave -n ${NAMESPACE}

<!-- TABS:END -->
```

**Key points:**
- Use `<!-- TABS:START -->` and `<!-- TABS:END -->` to wrap the entire tabbed section
- Use `<!-- TAB:Label -->` before each tab's content
- Add `:default` after the label to make it the default selected tab (e.g., `<!-- TAB:GKE:default -->`)
- **No imports needed** - the transformation automatically adds them
- On GitHub, the HTML comments are invisible, showing clean markdown
- On Docusaurus, these are transformed into proper `<Tabs>` components