### PR TITLE
Temp fix for auto inviter until we fix paid slack.

### DIFF
--- a/static/slack/index.html
+++ b/static/slack/index.html
@@ -7,7 +7,7 @@
     <!-- Centralized URL configuration -->
     <script>
         // Define the Slack invite URL in ONE place for easy updates
-        var SLACK_INVITE_URL = 'https://inviter.co/llm-d-slack';
+        var SLACK_INVITE_URL = 'https://join.slack.com/t/llm-d/shared_invite/zt-3mjey8mgj-BlDKYuaZ2~RUKRk7gAPPig';
         
         // Immediately write critical meta tags using the variable
         // This works because document.write executes during HTML parsing


### PR DESCRIPTION
The auto inviter stopped worked when the community slack flipped over to free tier (which should not have happened).  This is a temp fix to have a slack invite URL that will only work for a specific # of invites which i'll monitor and flip back to the inviter service when we fix our slack issues. 