### PR TITLE
Add January 2026 event 'Dynamo Day' to community events documentation

### DIFF
--- a/docs/community/events.md
+++ b/docs/community/events.md
@@ -12,6 +12,15 @@ Stay connected with the llm-d community at meetups, conferences, and workshops. 
 {(() => {
   const events = [
     {
+      month: 'January 2026',
+      title: 'Dynamo Day',
+      location: 'Virtual Event',
+      dateText: 'January 22, 2026',
+      cost: 'Free',
+      href: 'https://nvevents.nvidia.com/dynamoday/begin',
+      sessions: [],
+    },
+    {
       month: 'March 2026',
       title: 'KubeCon + CloudNativeCon Europe 2026',
       location: 'London, UK',


### PR DESCRIPTION
- Included details for 'Dynamo Day', a virtual event scheduled for January 22, 2026, with a free registration link.