### PR TITLE
Update link verification workflow to use new requirements and script URLs

### DIFF
--- a/.github/workflows/link-verification.yml
+++ b/.github/workflows/link-verification.yml
@@ -34,8 +34,8 @@ jobs:
         
     - name: Download and setup link verifier
       run: |
-        curl -o requirements.txt https://raw.githubusercontent.com/jjasghar/link-verifier-llm-d.ai/9930050b977f00f78dbe8d361814f359115df492/requirements.txt
-        curl -o link_verifier.py https://raw.githubusercontent.com/jjasghar/link-verifier-llm-d.ai/9930050b977f00f78dbe8d361814f359115df492/link_verifier.py
+        curl -o requirements.txt https://raw.githubusercontent.com/jjasghar/link-verifier-llm-d.ai/4857ce75decc793151c78211973a65bf18a22d7a/requirements.txt
+        curl -o link_verifier.py https://raw.githubusercontent.com/jjasghar/link-verifier-llm-d.ai/4857ce75decc793151c78211973a65bf18a22d7a/link_verifier.py
         pip install -r requirements.txt
         
     - name: Start the application in background


### PR DESCRIPTION
Sometimes the link checker will fail, likely due to bot detection, so the updated script uses a curl failback. https://github.com/jjasghar/link-verifier-llm-d.ai/pull/40