### PR TITLE
Correct figure reference in performance discussion

### DIFF
--- a/blog/2026-02-04_llm-d-v0.5-sustaining-performance-at-scale.md
+++ b/blog/2026-02-04_llm-d-v0.5-sustaining-performance-at-scale.md
@@ -75,7 +75,7 @@ In v0.5, we introduce the \`llm-d FS backend\`, a storage connector that plugs i
 * **Cross-replica reuse:** Unlike local CPU caches, which are isolated to a single instance, a shared file system acts as a persistent, global store of KV states. New nodes added to the cluster can "hydrate" their cache immediately from the shared tier, bypassing the warm-up phase typically required for new replicas.  
 * **Asynchronous design:** To minimize interference with the decoding loop, the backend utilizes fully asynchronous I/O and parallel worker threads. This ensures that the latency cost of fetching blocks from disk does not block the main compute path.
 
-Our internal benchmarks illustrate that the primary value of this architecture is operational stability under load. As shown in Figure 4, standard GPU-only deployments experience a sharp performance collapse once HBM is saturated. In contrast, the storage-backed configuration creates a "performance floor," sustaining throughput as user concurrency increases well beyond local memory limits.
+Our internal benchmarks illustrate that the primary value of this architecture is operational stability under load. As shown in Figure 3, standard GPU-only deployments experience a sharp performance collapse once HBM is saturated. In contrast, the storage-backed configuration creates a "performance floor," sustaining throughput as user concurrency increases well beyond local memory limits.
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
   <img src={require('../docs/assets/images/kvcache-throughput.png').default} alt="KV-cache throughput" style={{width: '75%', height: 'auto'}} />


### PR DESCRIPTION
Updated figure reference from Figure 4 to Figure 3 in the discussion of operational stability under load.  Figure name was changed but not the reference. 