### PR TITLE
Pin upload-pages-artifact action version in deploy workflow to v3.0.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm run build
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: build
 


### PR DESCRIPTION
The [4.0 release](https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0) included a breaking change which doesn't include dotfiles in the tar file artifact sync.  for simplicity just going back to pin to the 3.0.1 release based on sha `56afc609e74202658d3ffba0e8f6dda462b719fa`

In the future we can consider just creating our own artifact ( If you need to include dotfiles in your artifact: instead of using this action, create your own artifact according to these requirements https://github.com/actions/upload-pages-artifact?tab=readme-ov-file#artifact-validation)but not necessary for now
