### PR TITLE
🐛 Add Ofer to typos allowlist

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -9,5 +9,8 @@ aks = "aks"
 Nam = "Nam"
 nam = "nam"
 
+# Person's name (blog/authors.yml)
+Ofer = "Ofer"
+
 # Pre-existing typo in codebase (to be fixed separately)
 Kuberentes = "Kuberentes"


### PR DESCRIPTION
## Summary

- Add `Ofer` to `_typos.toml` allowlist — it's a person's name in `blog/authors.yml`, not a typo
- Prevents false positive in nightly typo scan

Closes #204