### PR TITLE
Add redirect page for Prism app

### DIFF
--- a/static/prism/index.html
+++ b/static/prism/index.html
@@ -100,8 +100,8 @@
         <h1>Redirecting to Prism</h1>
         
         <div class="redirecting-text">
-            <div class="spinner"></div>
-            <span id="redirect-message">Redirecting you to Prism in <span id="countdown">2</span> seconds...</span>
+            <div class="spinner" aria-hidden="true"></div>
+            <span id="redirect-message" aria-live="polite">Redirecting you to Prism in <span id="countdown">2</span> seconds...</span>
         </div>
         
         <p>

--- a/static/slack/index.html
+++ b/static/slack/index.html
@@ -100,8 +100,8 @@
         <h1>Join the llm-d Slack Community</h1>
         
         <div class="redirecting-text">
-            <div class="spinner"></div>
-            <span id="redirect-message">Redirecting you to our Slack invitation page in <span id="countdown">2</span> seconds...</span>
+            <div class="spinner" aria-hidden="true"></div>
+            <span id="redirect-message" aria-live="polite">Redirecting you to our Slack invitation page in <span id="countdown">2</span> seconds...</span>
         </div>
         
         <p>


### PR DESCRIPTION
## What does this PR do?

Adds a redirect for the Prism application similar to how we redirect for slack

## Why is this change needed?

Per @seanhorgan in the community slack, We want an easy to share "friendly" url that can redirect to Prism while its being built out with expanded benchmarking results. 

## How was this tested?

- [x] npm run start and going to localhost:3000/prism redirects successfully
## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run start`)
- [x] Documentation updated (if applicable)
