### PR TITLE
Pin this to the correct last working version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@b2f188c0c6e9a3d7b6f0c6f0c7c5b6d8e7f9a123 # v5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
The dependabot updates I made used the wrong commit for deploy-actions - i want this pinned to the last working version as the v5 has a breaking change.

