### PR TITLE
Enable hidden files in artifact upload for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
+          include-hidden-files: true
           path: build
 
   deploy:

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -90,7 +90,7 @@ cp "$WIP/architecture/advanced/kv-offloader.md"     "$DOCS_DIR/architecture/adva
 cp "$WIP/architecture/advanced/latency-predictor.md" "$DOCS_DIR/architecture/advanced/latency-predictor.md"
 
 # Architecture / Advanced / Autoscaling
-cp "$WIP/architecture/advanced/autoscaling/autoscaling.md"                  "$DOCS_DIR/architecture/advanced/autoscaling/index.md"
+cp "$WIP/architecture/advanced/autoscaling/README.md"                       "$DOCS_DIR/architecture/advanced/autoscaling/index.md"
 cp "$WIP/architecture/advanced/autoscaling/workload-variant-autoscaler.md"  "$DOCS_DIR/architecture/advanced/autoscaling/workload-variant-autoscaling.md"
 cp "$WIP/architecture/advanced/autoscaling/igw-hpa.md"                     "$DOCS_DIR/architecture/advanced/autoscaling/igw-hpa.md"
 

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -91,8 +91,8 @@ cp "$WIP/architecture/advanced/latency-predictor.md" "$DOCS_DIR/architecture/adv
 
 # Architecture / Advanced / Autoscaling
 cp "$WIP/architecture/advanced/autoscaling/README.md"                       "$DOCS_DIR/architecture/advanced/autoscaling/index.md"
-cp "$WIP/architecture/advanced/autoscaling/workload-variant-autoscaler.md"  "$DOCS_DIR/architecture/advanced/autoscaling/workload-variant-autoscaling.md"
-cp "$WIP/architecture/advanced/autoscaling/igw-hpa.md"                     "$DOCS_DIR/architecture/advanced/autoscaling/igw-hpa.md"
+cp "$WIP/architecture/advanced/autoscaling/wva.md"                         "$DOCS_DIR/architecture/advanced/autoscaling/workload-variant-autoscaling.md"
+cp "$WIP/architecture/advanced/autoscaling/hpa-keda.md"                    "$DOCS_DIR/architecture/advanced/autoscaling/igw-hpa.md"
 
 # === Well-Lit Paths ===
 cp "$WIP/well-lit-paths/README.md"        "$DOCS_DIR/well-lit-paths/index.md"


### PR DESCRIPTION
Allow inclusion of hidden files in the build artifact upload.

## What does this PR do?

adds the `build-with-hidden-files` enabled 

## Why is this change needed?

the `.well-known` directory was being excluded, breaking BlueSky
## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [ ] Site builds successfully (`npm run build`)
- [ ] Manual testing performed (`npm start`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [ ] Tests pass locally (`npm test`)
- [ ] Site builds without errors (`npm run build`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #243 
