### PR TITLE
Update slack invite URL

### DIFF
--- a/static/slack/index.html
+++ b/static/slack/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="refresh" content="2; url=https://join.slack.com/t/llm-d/shared_invite/zt-3mjey8mgj-BlDKYuaZ2~RUKRk7gAPPig">
-    <link rel="canonical" href="https://join.slack.com/t/llm-d/shared_invite/zt-3mjey8mgj-BlDKYuaZ2~RUKRk7gAPPig">
+    <meta http-equiv="refresh" content="2; url=https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw">
+    <link rel="canonical" href="https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw">
     
     <!-- Page title and meta information -->
     <title>Redirecting to llm-d Slack Community</title>
@@ -15,7 +15,7 @@
     <meta property="og:title" content="Join llm-d Slack Community">
     <meta property="og:description" content="Join the llm-d community on Slack">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://join.slack.com/t/llm-d/shared_invite/zt-3mjey8mgj-BlDKYuaZ2~RUKRk7gAPPig">
+    <meta property="og:url" content="https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw">
     
     <!-- Twitter Card tags -->
     <meta name="twitter:card" content="summary">
@@ -105,7 +105,7 @@
         </div>
         
         <p>
-            <a href="https://join.slack.com/t/llm-d/shared_invite/zt-3mjey8mgj-BlDKYuaZ2~RUKRk7gAPPig" id="fallback-link" class="redirect-link">
+            <a href="https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw" id="fallback-link" class="redirect-link">
                 Click here if you are not redirected automatically
             </a>
         </p>
@@ -114,14 +114,14 @@
             <p><strong>If the redirect doesn't work:</strong></p>
             <p>Please copy and paste this URL into your browser:</p>
             <p id="manual-url" style="word-break: break-all; font-family: monospace; background: #f8f9fa; padding: 10px; border-radius: 4px;">
-                https://join.slack.com/t/llm-d/shared_invite/zt-3mjey8mgj-BlDKYuaZ2~RUKRk7gAPPig
+                https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw
             </p>
         </div>
     </div>
 
     <!-- Progressive enhancement: countdown timer and JS redirect -->
     <script>
-        var REDIRECT_URL = 'https://join.slack.com/t/llm-d/shared_invite/zt-3mjey8mgj-BlDKYuaZ2~RUKRk7gAPPig';
+        var REDIRECT_URL = 'https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw';
         let timeLeft = 2;
         const countdownElement = document.getElementById('countdown');
         const messageElement = document.getElementById('redirect-message');


### PR DESCRIPTION
## What does this PR do?

The slack invite URLs only work for up to 400 people then need to be renewed - we used to use inviter.co to send invites, but too many people join via invites and don't complete the invite process slack will not allow more email invites.  (Slack is incredibly hostile towards these open communities. 

## Why is this change needed?

This re-enables the invite link at https://llm-d.ai/slack

