### PR TITLE
fix: auto-resolve merge conflicts when syncing docs PRs

### DIFF
--- a/preview/scripts/merge-docs-prs.sh
+++ b/preview/scripts/merge-docs-prs.sh
@@ -71,11 +71,40 @@ for pr in json.load(sys.stdin):
         continue
     fi
 
-    if git merge --no-edit "pr-${PR_NUM}" --quiet 2>/dev/null; then
+    # Try merge with theirs strategy (prefer PR changes for content conflicts)
+    if git merge --no-edit "pr-${PR_NUM}" -X theirs 2>/dev/null; then
         echo "INCLUDED: #$PR_NUM - $PR_TITLE" | tee -a "$REPORT"
     else
-        git merge --abort 2>/dev/null || true
-        echo "SKIPPED (conflict): #$PR_NUM - $PR_TITLE" | tee -a "$REPORT"
+        # Merge failed - try to auto-resolve common conflicts
+        echo "    Attempting auto-conflict resolution..."
+
+        # Check for directory rename conflicts (guides/ → well-lit-paths/)
+        if git status --porcelain | grep -q "DU\|UD\|AA\|UA\|AU"; then
+            # Handle deleted/modified and rename conflicts
+            git status --porcelain | while read status file; do
+                case "$status" in
+                    DU|UD)
+                        # Deleted in one branch, modified in other - keep modified version
+                        git add "$file" 2>/dev/null || true
+                        ;;
+                    AA|UA|AU)
+                        # Both added/modified - keep PR version
+                        git checkout --theirs "$file" 2>/dev/null && git add "$file" || true
+                        ;;
+                esac
+            done
+
+            # Try to complete the merge
+            if git commit --no-edit 2>/dev/null; then
+                echo "INCLUDED (auto-resolved): #$PR_NUM - $PR_TITLE" | tee -a "$REPORT"
+            else
+                git merge --abort 2>/dev/null || true
+                echo "SKIPPED (unresolvable conflict): #$PR_NUM - $PR_TITLE" | tee -a "$REPORT"
+            fi
+        else
+            git merge --abort 2>/dev/null || true
+            echo "SKIPPED (conflict): #$PR_NUM - $PR_TITLE" | tee -a "$REPORT"
+        fi
     fi
 done
 

--- a/preview/scripts/merge-docs-prs.sh
+++ b/preview/scripts/merge-docs-prs.sh
@@ -20,7 +20,7 @@ echo "==> Cloning llm-d/llm-d@main into $CLONE_DIR"
 if [[ ! -d "$CLONE_DIR/.git" ]]; then
     git clone --depth 100 --branch main --filter=blob:none --sparse \
         "$REPO_URL" "$CLONE_DIR" --quiet
-    (cd "$CLONE_DIR" && git sparse-checkout set docs/wip-docs-new docs/assets)
+    (cd "$CLONE_DIR" && git sparse-checkout set docs/wip-docs-new docs/assets guides)
 else
     echo "    Using existing clone at $CLONE_DIR"
 fi

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -132,6 +132,7 @@ cp_doc "$WIP/well-lit-paths/kv-cache-management.md"                 "$DOCS_DIR/g
 cp_doc "$WIP/well-lit-paths/pd-disaggregation.md"                   "$DOCS_DIR/guides/pd-disaggregation.md"
 cp_doc "$WIP/well-lit-paths/wide-expert-parallelism.md"             "$DOCS_DIR/guides/wide-expert-parallelism.md"
 cp_doc "$WIP/well-lit-paths/intelligent-inference-scheduling.md"    "$DOCS_DIR/guides/intelligent-inference-scheduling.md"
+cp_doc "$WIP/well-lit-paths/optimized-baseline.md"               "$DOCS_DIR/guides/intelligent-inference-scheduling.md"
 cp_doc "$WIP/well-lit-paths/experimental/predicted-latency.md"      "$DOCS_DIR/guides/experimental/predicted-latency.md"
 
 # === Resources (formerly guides) ===

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -134,6 +134,7 @@ cp_doc "$WIP/well-lit-paths/wide-expert-parallelism.md"             "$DOCS_DIR/g
 cp_doc "$WIP/well-lit-paths/intelligent-inference-scheduling.md"    "$DOCS_DIR/guides/intelligent-inference-scheduling.md"
 cp_doc "$WIP/well-lit-paths/optimized-baseline.md"               "$DOCS_DIR/guides/intelligent-inference-scheduling.md"
 cp_doc "$WIP/well-lit-paths/experimental/predicted-latency.md"      "$DOCS_DIR/guides/experimental/predicted-latency.md"
+cp_doc "$WIP/well-lit-paths/experimental/batch-gateway.md"        "$DOCS_DIR/guides/experimental/batch-gateway.md"
 
 # === Resources (formerly guides) ===
 cp_doc "$WIP/resources/deploying-multiple-model.md"         "$DOCS_DIR/resources/deploying-multiple-models.md"

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -146,9 +146,10 @@ cp_doc "$WIP/resources/monitoring/tracing.md"               "$DOCS_DIR/resources
 # PR #1207 places monitoring under guides/monitoring/ — use as fallback
 cp_doc "$WIP/guides/monitoring/metrics.md"                  "$DOCS_DIR/resources/monitoring/metrics.md"
 cp_doc "$WIP/guides/monitoring/tracing.md"                  "$DOCS_DIR/resources/monitoring/tracing.md"
-cp_doc "$WIP/resources/gateways/istio.md"                   "$DOCS_DIR/resources/gateway/istio.md"
-cp_doc "$WIP/resources/gateways/gke.md"                     "$DOCS_DIR/resources/gateway/gke.md"
-cp_doc "$WIP/resources/gateways/agentgateway.md"            "$DOCS_DIR/resources/gateway/agentgateway.md"
+# PR #1259 moved gateway docs to guides/prereq/gateways/
+cp_doc "$SRC/guides/prereq/gateways/istio.md"               "$DOCS_DIR/resources/gateway/istio.md"
+cp_doc "$SRC/guides/prereq/gateways/gke.md"                 "$DOCS_DIR/resources/gateway/gke.md"
+cp_doc "$SRC/guides/prereq/gateways/agentgateway.md"        "$DOCS_DIR/resources/gateway/agentgateway.md"
 cp_doc "$WIP/resources/rdma/README.md"                      "$DOCS_DIR/resources/rdma/rdma-configuration.md"
 
 # === API Reference ===


### PR DESCRIPTION
## Problem

The preview site was missing content from several docs PRs because they had merge conflicts and were being skipped:
- #1170 - intelligent-inference-scheduling content (was showing stub instead)
- #1187 - batch-gateway documentation (entire section missing)
- #1140 - typo fixes

These PRs conflict because they were created before the `guides/` → `well-lit-paths/` directory rename in main.

## Solution

Updated `merge-docs-prs.sh` to auto-resolve common conflict types:
- Use `-X theirs` merge strategy (prefer PR changes for content conflicts)
- Auto-resolve delete/modify conflicts (keep PR version)
- Auto-resolve both-added conflicts (keep PR version)

## Result

Now merges successfully:
- ✅ #1140 - typo fixes
- ✅ #1170 - intelligent-inference-scheduling content  
- ✅ #1187 - batch-gateway documentation
- ⏭️  #1247 - still skipped (complex rename/rename, not critical)

Preview will show actual content instead of stubs.