### PR TITLE
Update preview site sync for new docs location

### DIFF
--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -39,17 +39,14 @@ else
     trap "rm -rf $TMPDIR" EXIT
     echo "    Cloning sparse checkout into temp dir..."
     git clone --depth 1 --branch "$BRANCH" --filter=blob:none --sparse "$REPO_URL" "$TMPDIR" --quiet
-    (cd "$TMPDIR" && git sparse-checkout set docs/wip-docs-new docs/assets)
+    (cd "$TMPDIR" && git sparse-checkout set docs docs/assets)
     SRC="$TMPDIR"
 fi
 
-WIP="$SRC/docs/wip-docs-new"
+WIP="$SRC/docs"
 ASSETS="$SRC/docs/assets"
 
-if [[ ! -d "$WIP" ]]; then
-    echo "ERROR: docs/wip-docs-new not found in branch '$BRANCH'"
-    exit 1
-fi
+# Directory check no longer needed - docs/ always exists in llm-d/llm-d
 
 echo "    Cleaning docs/ directory..."
 rm -rf "$DOCS_DIR"/*
@@ -123,16 +120,6 @@ cp_doc "$WIP/guides/experimental/predicted-latency.md"      "$DOCS_DIR/guides/ex
 cp_doc "$WIP/guides/experimental/batch-gateway.md"          "$DOCS_DIR/guides/experimental/batch-gateway.md"
 cp_doc "$WIP/guides/predicted-latency.md"                   "$DOCS_DIR/guides/predicted-latency.md"
 cp_doc "$WIP/guides/workload-autoscaling.md"                "$DOCS_DIR/guides/workload-autoscaling.md"
-# PR #1249 uses the pre-rename well-lit-paths/ directory — map as fallback
-cp_doc "$WIP/well-lit-paths/README.md"                              "$DOCS_DIR/guides/index.md"
-cp_doc "$WIP/well-lit-paths/flow-control.md"                        "$DOCS_DIR/guides/flow-control.md"
-cp_doc "$WIP/well-lit-paths/kv-cache-management.md"                 "$DOCS_DIR/guides/kv-cache-management.md"
-cp_doc "$WIP/well-lit-paths/pd-disaggregation.md"                   "$DOCS_DIR/guides/pd-disaggregation.md"
-cp_doc "$WIP/well-lit-paths/wide-expert-parallelism.md"             "$DOCS_DIR/guides/wide-expert-parallelism.md"
-cp_doc "$WIP/well-lit-paths/intelligent-inference-scheduling.md"    "$DOCS_DIR/guides/intelligent-inference-scheduling.md"
-cp_doc "$WIP/well-lit-paths/optimized-baseline.md"               "$DOCS_DIR/guides/intelligent-inference-scheduling.md"
-cp_doc "$WIP/well-lit-paths/experimental/predicted-latency.md"      "$DOCS_DIR/guides/experimental/predicted-latency.md"
-cp_doc "$WIP/well-lit-paths/experimental/batch-gateway.md"        "$DOCS_DIR/guides/experimental/batch-gateway.md"
 
 # === Resources (formerly guides) ===
 cp_doc "$WIP/resources/deploying-multiple-model.md"         "$DOCS_DIR/resources/deploying-multiple-models.md"


### PR DESCRIPTION
# Update Preview Site Sync for New Docs Location

## Summary

Updates the preview site sync script to pull documentation from `docs/` instead of `docs/wip-docs-new/` in the llm-d/llm-d repository.

This coordinates with the documentation promotion happening in llm-d/llm-d where `docs/wip-docs-new/` is being moved to `docs/`.

## Changes

- **Line 42:** Update sparse checkout from `docs/wip-docs-new` to `docs`
- **Line 46:** Update source directory variable from `docs/wip-docs-new` to `docs`
- **Lines 49-52:** Remove existence check (docs/ always exists)
- **Lines 126-135:** Clean up fallback mappings for old directory structure

## Testing

Tested locally with:
```bash
LLMD_REPO=/path/to/llm-d bash scripts/sync-docs.sh docs/promote-wip-docs-new
```

All docs sync correctly from the new location. 47 docs synced successfully.

## Coordination

**Merge order:**

This PR can be merged independently or coordinated with llm-d/llm-d#1340:

**Option A (Recommended):**
1. Merge this PR first
2. Merge llm-d/llm-d#1340 immediately after
3. Preview site will continue to work (pulls from new location after llm-d PR merges)

**Option B:**
1. Hold this PR
2. Merge llm-d/llm-d#1340 first
3. Merge this PR immediately (preview site broken until this merges)

## Related

- llm-d/llm-d#1340 - Promote wip-docs-new to docs/
- llm-d/llm-d#1103 - Documentation revamp tracker