### PR TITLE
Preserve router/ directory structure in docs sync

### DIFF
--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -57,7 +57,7 @@ rm -rf "$DOCS_DIR"/*
 echo "    Creating directory structure from outline..."
 mkdir -p \
     "$DOCS_DIR/getting-started" \
-    "$DOCS_DIR/architecture/core/epp" \
+    "$DOCS_DIR/architecture/core/router/epp" \
     "$DOCS_DIR/architecture/advanced/disaggregation" \
     "$DOCS_DIR/architecture/advanced/autoscaling" \
     "$DOCS_DIR/architecture/advanced/batch" \
@@ -79,17 +79,19 @@ cp_doc "$WIP/getting-started/artifacts.md"    "$DOCS_DIR/getting-started/artifac
 cp_doc "$WIP/architecture/README.md"          "$DOCS_DIR/architecture/index.md"
 
 # Architecture / Core
-cp_doc "$WIP/architecture/core/router/proxy.md"           "$DOCS_DIR/architecture/core/proxy.md"
 cp_doc "$WIP/architecture/core/inferencepool.md"   "$DOCS_DIR/architecture/core/inferencepool.md"
 cp_doc "$WIP/architecture/core/model-servers.md"   "$DOCS_DIR/architecture/core/model-servers.md"
 
-# Architecture / Core / EPP (moved under router/ in upstream)
-cp_doc "$WIP/architecture/core/router/epp/README.md"           "$DOCS_DIR/architecture/core/epp/index.md"
-cp_doc "$WIP/architecture/core/router/epp/scheduling.md"       "$DOCS_DIR/architecture/core/epp/scheduling.md"
-cp_doc "$WIP/architecture/core/router/epp/flow-control.md"     "$DOCS_DIR/architecture/core/epp/flow-control.md"
-cp_doc "$WIP/architecture/core/router/epp/request-handling.md"  "$DOCS_DIR/architecture/core/epp/request-handling.md"
-cp_doc "$WIP/architecture/core/router/epp/configuration.md"     "$DOCS_DIR/architecture/core/epp/configuration.md"
-cp_doc "$WIP/architecture/core/router/epp/datalayer.md"         "$DOCS_DIR/architecture/core/epp/datalayer.md"
+# Architecture / Core / Router
+cp_doc "$WIP/architecture/core/router/proxy.md"           "$DOCS_DIR/architecture/core/router/proxy.md"
+
+# Architecture / Core / Router / EPP
+cp_doc "$WIP/architecture/core/router/epp/README.md"           "$DOCS_DIR/architecture/core/router/epp/index.md"
+cp_doc "$WIP/architecture/core/router/epp/scheduling.md"       "$DOCS_DIR/architecture/core/router/epp/scheduling.md"
+cp_doc "$WIP/architecture/core/router/epp/flow-control.md"     "$DOCS_DIR/architecture/core/router/epp/flow-control.md"
+cp_doc "$WIP/architecture/core/router/epp/request-handling.md"  "$DOCS_DIR/architecture/core/router/epp/request-handling.md"
+cp_doc "$WIP/architecture/core/router/epp/configuration.md"     "$DOCS_DIR/architecture/core/router/epp/configuration.md"
+cp_doc "$WIP/architecture/core/router/epp/datalayer.md"         "$DOCS_DIR/architecture/core/router/epp/datalayer.md"
 
 # Architecture / Advanced / Disaggregation
 cp_doc "$WIP/architecture/advanced/disaggregation/README.md"            "$DOCS_DIR/architecture/advanced/disaggregation/index.md"
@@ -199,7 +201,7 @@ done
 
 # === Clean up known issues ===
 # Remove "NEEDS TO BE REDONE" from configuration.md
-sed_inplace '/^NEEDS TO BE REDONE/d' "$DOCS_DIR/architecture/core/epp/configuration.md" 2>/dev/null || true
+sed_inplace '/^NEEDS TO BE REDONE/d' "$DOCS_DIR/architecture/core/router/epp/configuration.md" 2>/dev/null || true
 
 # === Apply markdown transformations (shared with test-transformations.sh) ===
 echo "    Applying markdown transformations (callouts, tabs, MDX escaping)..."
@@ -252,7 +254,7 @@ generate_stub "$DOCS_DIR/resources/gateway/agentgateway.md" "Agent Gateway" "Dep
 generate_stub "$DOCS_DIR/architecture/advanced/batch/index.md" "Batch Processing" "Asynchronous batch inference architecture"
 generate_stub "$DOCS_DIR/architecture/advanced/batch/batch-gateway.md" "Batch Gateway" "Gateway for batch inference requests"
 generate_stub "$DOCS_DIR/architecture/advanced/batch/async-processor.md" "Async Processor" "Asynchronous request processing component"
-generate_stub "$DOCS_DIR/architecture/core/epp/datalayer.md" "Data Layer" "EPP data layer architecture"
+generate_stub "$DOCS_DIR/architecture/core/router/epp/datalayer.md" "Data Layer" "EPP data layer architecture"
 generate_stub "$DOCS_DIR/architecture/advanced/disaggregation/index.md" "Disaggregation" "Prefill/decode disaggregation architecture"
 generate_stub "$DOCS_DIR/architecture/advanced/disaggregation/configuration.md" "Disaggregation Configuration" "Configuration guide for disaggregated serving"
 generate_stub "$DOCS_DIR/architecture/advanced/disaggregation/operations-vllm.md" "vLLM Operations" "vLLM-specific operations for disaggregated serving"

--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -26,18 +26,24 @@ const sidebars: SidebarsConfig = {
           label: 'Core',
           collapsed: false,
           items: [
-            'architecture/core/proxy',
             'architecture/core/inferencepool',
             {
               type: 'category',
-              label: 'EPP',
-              link: {type: 'doc', id: 'architecture/core/epp/index'},
+              label: 'Router',
               items: [
-                'architecture/core/epp/scheduling',
-                'architecture/core/epp/flow-control',
-                'architecture/core/epp/request-handling',
-                'architecture/core/epp/configuration',
-                'architecture/core/epp/datalayer',
+                'architecture/core/router/proxy',
+                {
+                  type: 'category',
+                  label: 'EPP',
+                  link: {type: 'doc', id: 'architecture/core/router/epp/index'},
+                  items: [
+                    'architecture/core/router/epp/scheduling',
+                    'architecture/core/router/epp/flow-control',
+                    'architecture/core/router/epp/request-handling',
+                    'architecture/core/router/epp/configuration',
+                    'architecture/core/router/epp/datalayer',
+                  ],
+                },
               ],
             },
             'architecture/core/model-servers',


### PR DESCRIPTION
## Problem

The preview docs sync script flattens the `router/` directory structure when copying from llm-d/llm-d, which causes all relative links in markdown files to break on the website.

**Source structure (llm-d/llm-d):**
```
docs/architecture/core/router/proxy.md
docs/architecture/core/router/epp/README.md
docs/architecture/core/router/epp/scheduling.md
```

**Current website structure (broken):**
```
docs/architecture/core/proxy.md
docs/architecture/core/epp/index.md
docs/architecture/core/epp/scheduling.md
```

**Issue:** A link like `../../../advanced/disaggregation/README.md` works in the source repo but breaks on the website because the directory depth is different.

## Solution

Preserve the `router/` directory structure when syncing docs, so the website structure matches the source structure exactly.

**New website structure:**
```
docs/architecture/core/router/proxy.md
docs/architecture/core/router/epp/index.md
docs/architecture/core/router/epp/scheduling.md
```

**Result:** All relative links work correctly in both places.

## Changes

- **sync-docs.sh:** Update mkdir and cp_doc commands to preserve `router/` directory
- **sync-docs.sh:** Update sed and stub generation paths
- **sidebars.ts:** Add Router category containing proxy and EPP

## Testing

This needs to be tested by:
1. Running the sync script with the new structure
2. Building the preview site locally
3. Verifying all internal links work

## Related

- Addresses issue discovered in llm-d/llm-d#1340 where all relative links were fixed for the source repo but would break when synced to the website.
- Required before llm-d/llm-d#1340 can be merged and docs promoted to main.