### PR TITLE
Embed Prism dashboard in docs and fix missing sidebar item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "prism-react-renderer": "^2.3.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.6",
-        "react-player": "^2.16.1"
+        "react-player": "^2.16.1",
+        "resolve-pathname": "^3.0.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "prism-react-renderer": "^2.3.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.6",
-    "react-player": "^2.16.1"
+    "react-player": "^2.16.1",
+    "resolve-pathname": "^3.0.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.1",

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -68,6 +68,13 @@ echo "Step 3: Syncing and building dev docs from llm-d/llm-d @ $DEV_DOCS_BRANCH.
 echo "        Output: build/$DEV_OUTPUT_SUBDIR/ (baseUrl: $DEV_BASE_URL)"
 cd "$PROJECT_DIR/preview"
 bash scripts/sync-docs.sh "$DEV_DOCS_BRANCH"
+
+# === INJECT PRISM DASHBOARD ===
+echo "Injecting Prism dashboard into dev optimized-baseline.md..."
+echo -e '\n## Results Dashboard\n\nThe graphs below are powered by [Prism](https://prism.llm-d.ai/?view=intelligent-routing), our visualization dashboard for analyzing inference benchmark results. This specific view shows the performance of intelligent routing.\n\n<div style={{width: "100%", height: "600px", overflow: "hidden", position: "relative"}}><iframe src="https://prism.llm-d.ai/?view=intelligent-routing" style={{width: "150%", height: "150%", transform: "scale(0.67)", transformOrigin: "0 0", border: 0, position: "absolute", top: 0, left: 0}} allowFullScreen title="Prism Intelligent Routing Dashboard"></iframe></div>' >> "$PROJECT_DIR/preview/docs/guides/optimized-baseline.md"
+echo "✓ Dashboard injected"
+echo ""
+
 npm install
 DOCS_BASE_URL="$DEV_BASE_URL" npm run build
 cd "$PROJECT_DIR"
@@ -132,6 +139,10 @@ else
         -e 's|github.com/llm-d/llm-d/tree/main/guides/predicted-latency-based-scheduling|github.com/llm-d/llm-d/tree/main/guides/predicted-latency-routing|g' \
         "$file"
     done < <(find "${WORKTREE_PATH}/preview/docs" -name "*.md" -print0)
+
+    # Inject Prism dashboard into the worktree docs as well
+    echo "  Injecting Prism dashboard into release ${VERSION} optimized-baseline.md..."
+    echo -e '\n## Results Dashboard\n\nThe graphs below are powered by [Prism](https://prism.llm-d.ai/?view=intelligent-routing), our visualization dashboard for analyzing inference benchmark results. This specific view shows the performance of intelligent routing.\n\n<div style={{width: "100%", height: "600px", overflow: "hidden", position: "relative"}}><iframe src="https://prism.llm-d.ai/?view=intelligent-routing" style={{width: "150%", height: "150%", transform: "scale(0.67)", transformOrigin: "0 0", border: 0, position: "absolute", top: 0, left: 0}} allowFullScreen title="Prism Intelligent Routing Dashboard"></iframe></div>' >> "${WORKTREE_PATH}/preview/docs/guides/optimized-baseline.md"
 
     cd "${WORKTREE_PATH}/preview"
     npm install --silent


### PR DESCRIPTION
## What does this PR do?

At build time this appends a "Results Dashboard" section to the optimized-baseline guide with a blurb and iframe that embeds the corresponding Prism dashboard.

<img width="2522" height="1906" alt="image" src="https://github.com/user-attachments/assets/31212048-86a7-4b5f-a684-bd406b5bdefc" />

## Why is this change needed?

Adds Prism links to the documentation.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build`)
- [x] Manual testing performed (`npm start`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [ ] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
