### PR TITLE
Add release branch documentation sync infrastructure

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,0 +1,74 @@
+name: Create Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 0.7.0)'
+        required: true
+        type: string
+      source_branch:
+        description: 'Source branch in llm-d/llm-d (e.g., release-0.7)'
+        required: true
+        type: string
+
+jobs:
+  create-release-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and checkout release branch
+        run: |
+          git checkout -b release-${{ inputs.version }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.18.1
+          cache: npm
+          cache-dependency-path: preview/package-lock.json
+
+      - name: Install dependencies
+        run: cd preview && npm install
+
+      - name: Sync docs from llm-d/llm-d release branch
+        run: |
+          cd preview
+          bash scripts/sync-docs.sh ${{ inputs.source_branch }}
+
+      - name: Commit synced docs
+        run: |
+          git add preview/docs preview/static/img/docs
+          if ! git diff --staged --quiet; then
+            git commit -m "Initial docs sync from llm-d/llm-d@${{ inputs.source_branch }}"
+          else
+            echo "No changes to commit"
+          fi
+
+      - name: Push release branch
+        run: |
+          git push origin release-${{ inputs.version }}
+
+      - name: Summary
+        run: |
+          echo "## Release Branch Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch:** release-${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Source:** llm-d/llm-d@${{ inputs.source_branch }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Synced:** $(find preview/docs -name '*.md' | wc -l) markdown files" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Nightly sync will keep this branch updated from the source branch." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,47 @@ jobs:
       - name: Merge preview into main build as /docs
         run: cp -r preview/build build/docs
 
+      - name: Build and merge release branches
+        run: |
+          # Fetch all branches
+          git fetch origin
+
+          # Find all release branches
+          RELEASE_BRANCHES=$(git branch -r | grep 'origin/release-' | sed 's|origin/||' | grep -v HEAD || true)
+
+          if [ -z "$RELEASE_BRANCHES" ]; then
+            echo "No release branches found, skipping"
+            exit 0
+          fi
+
+          echo "Building release branches:"
+          echo "$RELEASE_BRANCHES"
+
+          for branch in $RELEASE_BRANCHES; do
+            # Extract version (e.g., release-0.7.0 -> 0.7.0)
+            VERSION=${branch#release-}
+
+            echo "Building docs for version $VERSION from $branch"
+
+            # Checkout the release branch (in a worktree to avoid conflicts)
+            git worktree add "../release-${VERSION}" "$branch"
+
+            # Build the release docs
+            cd "../release-${VERSION}/preview"
+            npm install
+            npm run build
+
+            # Copy build output to versioned path
+            mkdir -p "../../llm-d.github.io/build/docs/${VERSION}"
+            cp -r build/* "../../llm-d.github.io/build/docs/${VERSION}/"
+
+            # Clean up worktree
+            cd "../../llm-d.github.io"
+            git worktree remove "../release-${VERSION}"
+
+            echo "✓ Built version $VERSION"
+          done
+
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/.github/workflows/sync-release-docs.yml
+++ b/.github/workflows/sync-release-docs.yml
@@ -1,0 +1,101 @@
+name: Sync Release Branch Docs
+
+on:
+  schedule:
+    # Run nightly at 1:00 AM UTC (after main deploy at midnight)
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  discover-and-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.18.1
+          cache: npm
+          cache-dependency-path: preview/package-lock.json
+
+      - name: Install dependencies
+        run: cd preview && npm install
+
+      - name: Discover and sync release branches
+        run: |
+          # Fetch all remote branches
+          git fetch origin
+
+          # Find all release branches (e.g., release-0.7.0)
+          RELEASE_BRANCHES=$(git branch -r | grep 'origin/release-' | sed 's|origin/||' | grep -v HEAD || true)
+
+          if [ -z "$RELEASE_BRANCHES" ]; then
+            echo "No release branches found"
+            exit 0
+          fi
+
+          echo "Found release branches:"
+          echo "$RELEASE_BRANCHES"
+          echo ""
+
+          # Process each release branch
+          for branch in $RELEASE_BRANCHES; do
+            echo "========================================="
+            echo "Processing: $branch"
+            echo "========================================="
+
+            # Extract version (e.g., release-0.7.0 -> 0.7.0)
+            VERSION=${branch#release-}
+
+            # Extract major.minor for source branch (e.g., 0.7.0 -> 0.7)
+            MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+            SOURCE_BRANCH="release-${MAJOR_MINOR}"
+
+            echo "Version: $VERSION"
+            echo "Source branch in llm-d/llm-d: $SOURCE_BRANCH"
+
+            # Checkout the release branch
+            git checkout "$branch"
+            git pull origin "$branch"
+
+            # Sync docs from llm-d/llm-d
+            cd preview
+            bash scripts/sync-docs.sh "$SOURCE_BRANCH" || {
+              echo "Warning: Sync failed for $branch"
+              cd ..
+              continue
+            }
+            cd ..
+
+            # Commit changes if any
+            git add preview/docs preview/static/img/docs
+            if ! git diff --staged --quiet; then
+              COMMIT_MSG="Nightly docs sync from llm-d/llm-d@${SOURCE_BRANCH}
+
+          Auto-synced on $(date -u +"%Y-%m-%d %H:%M UTC")"
+              git commit -m "$COMMIT_MSG"
+              git push origin "$branch"
+              echo "✓ Updated $branch"
+            else
+              echo "✓ No changes for $branch"
+            fi
+
+            echo ""
+          done
+
+          echo "========================================="
+          echo "Sync complete"
+          echo "========================================="

--- a/preview/RELEASE-BRANCH-SYNC.md
+++ b/preview/RELEASE-BRANCH-SYNC.md
@@ -1,0 +1,189 @@
+# Release Branch Documentation Sync
+
+This document describes the release branch synchronization infrastructure for llm-d documentation.
+
+## Overview
+
+Starting with release 0.7.0, documentation for each release is maintained on dedicated release branches that sync nightly from the corresponding release branch in the main llm-d/llm-d repository.
+
+## Architecture
+
+### Branch Structure
+
+- **Main branch**: Always shows latest development docs (from llm-d/llm-d@main)
+- **Release branches**: Named `release-X.Y.Z` (e.g., `release-0.7.0`)
+  - Syncs nightly from `llm-d/llm-d@release-X.Y` 
+  - Deployed to `/docs/X.Y.Z/` on the website
+
+### Workflows
+
+#### 1. `create-release-branch.yml`
+
+**Purpose**: Create a new release branch for documentation
+
+**Trigger**: Manual (workflow_dispatch)
+
+**Inputs**:
+- `version`: Full version number (e.g., `0.7.0`)
+- `source_branch`: Source branch in llm-d/llm-d (e.g., `release-0.7`)
+
+**What it does**:
+1. Creates a new branch `release-{version}` from main
+2. Performs initial docs sync from llm-d/llm-d@{source_branch}
+3. Commits and pushes the new branch
+
+**Usage**:
+```bash
+gh workflow run create-release-branch.yml \
+  --repo llm-d/llm-d.github.io \
+  --field version=0.7.0 \
+  --field source_branch=release-0.7
+```
+
+#### 2. `sync-release-docs.yml`
+
+**Purpose**: Nightly sync of all release branches
+
+**Trigger**: Scheduled (1:00 AM UTC daily) + Manual
+
+**What it does**:
+1. Discovers all `release-*` branches
+2. For each branch:
+   - Extracts version (e.g., `release-0.7.0` → version `0.7.0`)
+   - Derives source branch (e.g., `0.7.0` → `release-0.7` in llm-d/llm-d)
+   - Syncs docs via `scripts/sync-docs.sh`
+   - Commits and pushes changes if any
+
+#### 3. `deploy.yml` (updated)
+
+**Purpose**: Build and deploy website + all release docs
+
+**What it does**:
+1. Builds main website
+2. Builds preview docs (dev/main)
+3. Discovers and builds all release branches
+4. Merges everything into a single artifact:
+   - `/` → Main website
+   - `/docs/` → Preview docs (dev)
+   - `/docs/0.7.0/` → Release 0.7.0 docs
+   - `/docs/0.8.0/` → Release 0.8.0 docs
+   - etc.
+
+### Version Picker
+
+The version dropdown component (`preview/src/components/VersionDropdown.tsx`) intelligently routes users:
+
+- **Version >= 0.7.0**: Links to `/docs/{version}/` on the website
+- **Version < 0.7.0**: Links to GitHub tree view (legacy releases)
+- **Page path preservation**: Maintains current page when switching versions
+  - Example: On `/docs/architecture` → Click v0.7.0 → Go to `/docs/0.7.0/architecture`
+
+## Creating a New Release
+
+Follow these steps when creating a new release:
+
+### 1. Create release branch in llm-d/llm-d
+
+```bash
+cd llm-d/llm-d
+git checkout -b release-0.7
+git push upstream release-0.7
+```
+
+### 2. Create documentation release branch
+
+Trigger the workflow to create the docs branch:
+
+```bash
+gh workflow run create-release-branch.yml \
+  --repo llm-d/llm-d.github.io \
+  --field version=0.7.0 \
+  --field source_branch=release-0.7
+```
+
+This step is integrated into the release process template at `.github/ISSUE_TEMPLATE/new-release.md`.
+
+### 3. Verify sync
+
+The branch will be created and synced immediately. Nightly syncs will keep it updated automatically.
+
+To manually trigger a sync:
+
+```bash
+gh workflow run sync-release-docs.yml --repo llm-d/llm-d.github.io
+```
+
+### 4. Deploy
+
+Deployment happens automatically on the next push to main or via the nightly build. Release docs are built and deployed alongside the main site.
+
+## URL Structure
+
+After creating release 0.7.0:
+
+- `https://llm-d.ai/` → Main website
+- `https://llm-d.ai/docs/` → Dev docs (main branch)
+- `https://llm-d.ai/docs/0.7.0/` → Release 0.7.0 docs
+- `https://llm-d.ai/docs/0.7.0/getting-started/` → Specific page in 0.7.0
+
+## Version Mapping
+
+| Release Branch (llm-d.github.io) | Source Branch (llm-d/llm-d) | Website Path |
+|----------------------------------|----------------------------|--------------|
+| `release-0.7.0` | `release-0.7` | `/docs/0.7.0/` |
+| `release-0.8.0` | `release-0.8` | `/docs/0.8.0/` |
+| `main` | `main` | `/docs/` (dev) |
+
+## Maintenance
+
+### Updating release docs
+
+Changes to release documentation should be made in the llm-d/llm-d release branch. They will sync automatically overnight. To sync immediately:
+
+```bash
+gh workflow run sync-release-docs.yml --repo llm-d/llm-d.github.io
+```
+
+### Patching release docs
+
+If you need to patch documentation for a specific release:
+
+1. Make changes in llm-d/llm-d on the release branch (e.g., `release-0.7`)
+2. Wait for nightly sync, or trigger manually
+3. Changes will appear on the website within minutes
+
+### Removing a release branch
+
+If a release branch needs to be removed:
+
+```bash
+git push origin --delete release-X.Y.Z
+```
+
+The next deployment will automatically skip the deleted branch.
+
+## Troubleshooting
+
+### Sync failures
+
+Check the workflow run logs:
+```bash
+gh run list --workflow=sync-release-docs.yml --repo llm-d/llm-d.github.io
+```
+
+Common issues:
+- Source branch doesn't exist in llm-d/llm-d
+- Merge conflicts (rare, but possible if files are manually edited)
+
+### Build failures
+
+Check the deploy workflow logs:
+```bash
+gh run list --workflow=deploy.yml --repo llm-d/llm-d.github.io
+```
+
+### Version not appearing in dropdown
+
+1. Verify the release tag exists in llm-d/llm-d
+2. Check that `preview/plugins/versions-plugin.js` is fetching tags correctly
+3. Rebuild the site to regenerate `static/releases.json`

--- a/preview/src/components/VersionDropdown.tsx
+++ b/preview/src/components/VersionDropdown.tsx
@@ -33,10 +33,22 @@ export default function VersionDropdown(): React.JSX.Element {
 
   // Extract current page path to preserve when switching versions
   // e.g., /docs/architecture/core/proxy -> architecture/core/proxy
+  // e.g., /docs/0.7.0/architecture -> architecture (strip version)
   const getCurrentPagePath = () => {
     const path = location.pathname;
     const match = path.match(/^\/docs\/(.+)$/);
-    return match ? match[1] : 'getting-started';
+    if (!match) return 'getting-started';
+
+    let pagePath = match[1];
+
+    // Strip version number if present (e.g., "0.7.0/architecture" -> "architecture")
+    // Version pattern: starts with digit(s).digit(s) optionally followed by .digit(s)
+    const versionMatch = pagePath.match(/^(\d+\.\d+(?:\.\d+)?)\/(.*)/);
+    if (versionMatch) {
+      pagePath = versionMatch[2];
+    }
+
+    return pagePath || 'getting-started';
   };
 
   // Generate URL for a version

--- a/preview/src/components/VersionDropdown.tsx
+++ b/preview/src/components/VersionDropdown.tsx
@@ -1,16 +1,63 @@
 import React from 'react';
 import {usePluginData} from '@docusaurus/useGlobalData';
+import {useLocation} from '@docusaurus/router';
 
 const REPO_URL = 'https://github.com/llm-d/llm-d/tree';
+const MIN_WEBSITE_VERSION = '0.7.0';
+
+// Compare semver versions (simple implementation for x.y.z format)
+function isVersionGTE(version: string, target: string): boolean {
+  const parseVersion = (v: string) => {
+    const stripped = v.replace(/^v/, '');
+    return stripped.split('.').map(n => parseInt(n, 10));
+  };
+
+  const [v1, v2] = [parseVersion(version), parseVersion(target)];
+
+  for (let i = 0; i < 3; i++) {
+    if ((v1[i] || 0) > (v2[i] || 0)) return true;
+    if ((v1[i] || 0) < (v2[i] || 0)) return false;
+  }
+  return true; // Equal
+}
 
 export default function VersionDropdown(): React.JSX.Element {
   const {releases} = usePluginData('llmd-versions-plugin') as {
     releases: string[];
   };
+  const location = useLocation();
 
   // Latest stable version (first in releases list)
   const latestTag = releases?.[0];
   const olderReleases = releases?.slice(1) || [];
+
+  // Extract current page path to preserve when switching versions
+  // e.g., /docs/architecture/core/proxy -> architecture/core/proxy
+  const getCurrentPagePath = () => {
+    const path = location.pathname;
+    const match = path.match(/^\/docs\/(.+)$/);
+    return match ? match[1] : 'getting-started';
+  };
+
+  // Generate URL for a version
+  const getVersionUrl = (tag: string) => {
+    const version = tag.replace(/^v/, '');
+    const pagePath = getCurrentPagePath();
+
+    if (isVersionGTE(version, MIN_WEBSITE_VERSION)) {
+      // Version 0.7.0+ hosted on website
+      return `/docs/${version}/${pagePath}`;
+    } else {
+      // Pre-0.7.0 versions link to GitHub
+      return `${REPO_URL}/${tag}/docs/wip-docs-new`;
+    }
+  };
+
+  // Check if link should open in new tab (GitHub links only)
+  const isExternalLink = (tag: string) => {
+    const version = tag.replace(/^v/, '');
+    return !isVersionGTE(version, MIN_WEBSITE_VERSION);
+  };
 
   return (
     <div className="navbar__item dropdown dropdown--hoverable">
@@ -32,11 +79,13 @@ export default function VersionDropdown(): React.JSX.Element {
             <li>
               <a
                 className="dropdown__link"
-                href={`${REPO_URL}/${latestTag}/docs`}
-                target="_blank"
-                rel="noopener noreferrer"
+                href={getVersionUrl(latestTag)}
+                {...(isExternalLink(latestTag) && {
+                  target: '_blank',
+                  rel: 'noopener noreferrer',
+                })}
               >
-                latest ({latestTag}) →
+                latest ({latestTag}){isExternalLink(latestTag) ? ' →' : ''}
               </a>
             </li>
           </>
@@ -47,11 +96,13 @@ export default function VersionDropdown(): React.JSX.Element {
               <li key={tag}>
                 <a
                   className="dropdown__link"
-                  href={`${REPO_URL}/${tag}/docs`}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  href={getVersionUrl(tag)}
+                  {...(isExternalLink(tag) && {
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                  })}
                 >
-                  {tag} →
+                  {tag}{isExternalLink(tag) ? ' →' : ''}
                 </a>
               </li>
             ))}


### PR DESCRIPTION
This PR implements a branch-per-release approach for documentation versioning, enabling automatic nightly synchronization of release documentation from the main llm-d repository.

## Overview

Starting with release 0.7.0, each release will have a dedicated branch in this repository that syncs nightly from the corresponding release branch in llm-d/llm-d. This ensures release documentation stays up-to-date with patches while remaining separate from development docs.

## Changes

### New Workflows

1. **`.github/workflows/create-release-branch.yml`**
   - Manually triggered workflow to create a new release branch
   - Takes version (e.g., `0.7.0`) and source branch (e.g., `release-0.7`)
   - Performs initial docs sync from llm-d/llm-d
   - Creates and pushes the new release branch

2. **`.github/workflows/sync-release-docs.yml`**
   - Scheduled nightly at 1:00 AM UTC
   - Discovers all `release-*` branches automatically
   - Syncs each branch from its corresponding llm-d/llm-d release branch
   - Commits and pushes changes if any

### Updated Files

3. **`.github/workflows/deploy.yml`**
   - Extended to build all release branches
   - Each release builds to `/docs/{version}/` path
   - Combined deployment with main site and dev docs

4. **`preview/src/components/VersionDropdown.tsx`**
   - Versions >= 0.7.0 link to website docs (`/docs/{version}/`)
   - Versions < 0.7.0 link to GitHub (legacy releases)
   - Preserves current page path when switching versions
   - Example: On `/docs/architecture` → Click v0.7.0 → Go to `/docs/0.7.0/architecture`

### Documentation

5. **`preview/RELEASE-BRANCH-SYNC.md`**
   - Comprehensive guide to the release branch sync infrastructure
   - Explains architecture, workflows, and maintenance procedures
   - Includes troubleshooting and usage examples

## URL Structure

After release 0.7.0 is created:

- `https://llm-d.ai/` → Main website
- `https://llm-d.ai/docs/` → Dev docs (main branch)
- `https://llm-d.ai/docs/0.7.0/` → Release 0.7.0 docs
- `https://llm-d.ai/docs/0.8.0/` → Release 0.8.0 docs (when created)

## Integration with Release Process

This infrastructure integrates with the release process via PR llm-d/llm-d#1492, which adds a documentation step to the release template:

```bash
gh workflow run create-release-branch.yml \
  --repo llm-d/llm-d.github.io \
  --field version=${MAJOR}.${MINOR}.${PATCH} \
  --field source_branch=release-${MAJOR}.${MINOR}
```

## Relationship to Existing VERSIONING.md

This PR implements a **branch-per-release** approach, which differs from the Docusaurus snapshot approach described in `preview/VERSIONING.md`. The branch-per-release approach is better suited for:

- Continuous sync with release branches (nightly updates)
- Different documentation structures per release
- Patch-level documentation updates without manual re-snapshotting

## Testing Plan

1. Merge this PR
2. When 0.7 release branch is created in llm-d/llm-d, trigger the workflow:
   ```bash
   gh workflow run create-release-branch.yml \
     --repo llm-d/llm-d.github.io \
     --field version=0.7.0 \
     --field source_branch=release-0.7
   ```
3. Verify branch is created and synced
4. Wait for next deployment or trigger manually
5. Verify docs appear at `/docs/0.7.0/`
6. Verify version picker shows 0.7.0 and links correctly

## See Also

- llm-d/llm-d#1492 - Release template update
- `preview/RELEASE-BRANCH-SYNC.md` - Full infrastructure documentation