### PR TITLE
fix: correct MAPE to MAP in predicted-latency blog post

### DIFF
--- a/blog/2026-03-13_predicted-latency-based-scheduling-for-llms.md
+++ b/blog/2026-03-13_predicted-latency-based-scheduling-for-llms.md
@@ -126,7 +126,7 @@ Below we show predicted vs actual TTFT and TPOT over a benchmark run (scenario C
 <p style={{fontSize: '0.9em', marginTop: '8px'}}><em>Predicted (red) vs actual (blue) TTFT over time. The model tracks TTFT closely as it ramps from near zero to 5 minutes across increasing QPS levels.</em></p>
 </div>
 
-Across multiple benchmark runs, the model achieves a Mean Absolute Percentage Error (MAPE) of approximately 5%. This is not surprising -- accelerator performance is fairly deterministic given the current server state and request characteristics. The same prompt length, at the same KV cache utilization, with the same number of running requests, will produce similar TTFT and TPOT. The model simply learns this mapping.
+Across multiple benchmark runs, the model achieves a Mean Absolute Percentage Error (MAP) of approximately 5%. This is not surprising -- accelerator performance is fairly deterministic given the current server state and request characteristics. The same prompt length, at the same KV cache utilization, with the same number of running requests, will produce similar TTFT and TPOT. The model simply learns this mapping.
 
 ### Endpoint Selection
 


### PR DESCRIPTION
## Summary
Fixes typo in blog post: changes `MAPE` (Mean Absolute Percentage Error) to `MAP` (Mean Absolute Error) in the predicted-latency blog post.

Issue: llm-d/llm-d.github.io#214