### PR TITLE
Add typos configuration updates

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,6 +1,9 @@
 # Typos configuration for llm-d.github.io
 # https://github.com/crate-ci/typos
 
+[files]
+extend-exclude = ["docs-archive-pre-v0.7"]
+
 [default.extend-words]
 # Azure Kubernetes Service abbreviation
 AKS = "AKS"
@@ -11,6 +14,9 @@ nam = "nam"
 
 # Person's name (blog/authors.yml)
 Ofer = "Ofer"
+
+# Mean Absolute Percentage Error metric abbreviation
+MAPE = "MAPE"
 
 # Pre-existing typo in codebase (to be fixed separately)
 Kuberentes = "Kuberentes"


### PR DESCRIPTION
## What does this PR do?

- Extended the exclude list to include "docs-archive-pre-v0.7".
- Added abbreviation for Mean Absolute Percentage Error (MAPE) to the configuration.

## Why is this change needed?

Adding exclusions for backup files and ignoring abbreviations

## Related Issues

https://github.com/llm-d/llm-d.github.io/issues/214
