### PR TITLE
Add /slack redirect to Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,12 @@
   command = "npm run build:all"
   publish = "build"
 
+# Slack invite redirect
+[[redirects]]
+  from = "/slack"
+  to = "https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw"
+  status = 302
+
 # Redirect old /preview/* to /docs/* (backward compatibility)
 [[redirects]]
   from = "/preview/*"


### PR DESCRIPTION
This PR adds a direct Netlify redirect for `/slack` to the Slack invite URL, fixing broken links in blog posts.

## Problem

Multiple blog posts reference `/slack`:
- `blog/2025-06-03_week_1_round_up.md`
- `blog/2025-05-20_announce.md` 
- `blog/2025-09-03_intelligent-inference-scheduling-with-llm-d.md`
- `blog/2025-06-25_community_update.md`
- `blog/2025-09-24_kvcache-wins-you-can-see.md`

Currently `/slack` redirects to `/slack/` (static HTML page), which then meta-refreshes to the Slack invite. This causes link checker failures.

## Solution

Add a direct 302 redirect in `netlify.toml`:
```toml
[[redirects]]
  from = "/slack"
  to = "https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw"
  status = 302
```

This simplifies the redirect chain and fixes the broken link errors.

## Testing

After deployment, verify:
- `/slack` redirects directly to Slack invite
- Blog links work correctly
- Link checker passes for `/slack` references