### PR TITLE
Add missing docs from upstream to site

### DIFF
--- a/blog/2025-09-24_kvcache-wins-you-can-see.md
+++ b/blog/2025-09-24_kvcache-wins-you-can-see.md
@@ -18,7 +18,7 @@ tags: [blog, updates, llm-d]
 
 The llm-d project provides a series of “well-lit paths” \- tested, benchmarked solutions for deploying large language models in production. Our first path, [**Intelligent Inference Scheduling**](/blog/intelligent-inference-scheduling-with-llm-d), established a baseline for AI-aware routing by balancing both cluster load and prefix-cache affinities. The default configuration for that path uses an *approximate* method for the latter, predicting cache locality based on request traffic.
 
-This blog illuminates a more advanced and powerful path: [**precise prefix-cache aware scheduling**](/docs/guides/precise-prefix-cache-aware).
+This blog illuminates a more advanced and powerful path: [**precise prefix-cache aware scheduling**](/docs/guides/precise-prefix-cache-routing).
 
 We take a deep dive into the next generation of this feature, which moves beyond prediction and gives the scheduler direct introspection into distributed vLLM caches. This precision is key to maximizing cache hit rates and achieving a new level of performance and maximizing cost-efficiency in your distributed deployments.
 

--- a/preview/docusaurus.config.ts
+++ b/preview/docusaurus.config.ts
@@ -75,6 +75,12 @@ const config: Config = {
             const cleanPath = docPath.replace(/^docs\//, '');
             // Map index.md back to README.md (sync script renames these)
             const sourcePath = cleanPath.replace(/\/index\.md$/, '/README.md');
+
+            // Guide pages come from guides/ in the upstream repo, not docs/
+            if (cleanPath.startsWith('guides/')) {
+              return `https://github.com/llm-d/llm-d/blob/main/${sourcePath}`;
+            }
+
             return `https://github.com/llm-d/llm-d/blob/main/docs/${sourcePath}`;
           },
           showLastUpdateTime: true,

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -144,6 +144,17 @@ find "$SRC/guides" -name "README.md" -type f 2>/dev/null | grep -v "/prereq/" | 
     cp "$readme_file" "$dst_path"
 done
 
+# Fix unclosed tab blocks in upstream content
+echo "    Fixing unclosed tab blocks..."
+# experimental-dp-aware has <!-- TABS:START --> and <!-- TAB:CoreWeave --> but missing <!-- TABS:END -->
+# The tab should close after the kubectl command, before "### Deploy InferencePool"
+if [[ -f "$DOCS_DIR/guides/wide-ep-lws/experimental-dp-aware/index.md" ]]; then
+    # Insert <!-- TABS:END --> before the "### Deploy InferencePool" heading
+    sed_inplace '/^### Deploy InferencePool$/i\
+<!-- TABS:END -->\
+' "$DOCS_DIR/guides/wide-ep-lws/experimental-dp-aware/index.md"
+fi
+
 echo "    Copying well-lit-paths overview pages as fallback..."
 
 # Copy well-lit-paths overview as top-level guides/index.md
@@ -248,6 +259,21 @@ find "$SRC/guides" -type d -name "images" 2>/dev/null | grep -v "/prereq/" | gre
 
     # Copy all images from this directory
     find "$img_dir" -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.svg" -o -name "*.gif" \) -exec cp {} "$dest_dir/" \; 2>/dev/null || true
+done
+
+# Guide benchmark-results - copy with directory structure preserved
+# Exclude prereq and experimental directories
+echo "    Copying guide benchmark-results..."
+find "$SRC/guides" -type d -name "benchmark-results" 2>/dev/null | grep -v "/prereq/" | grep -v "/experimental/" | while read -r bench_dir; do
+    # Calculate relative path from guides/
+    rel_path="${bench_dir#$SRC/guides/}"
+
+    # Create destination directory structure (e.g., /img/docs/guides/precise-prefix-cache-aware/benchmark-results/)
+    dest_dir="$STATIC_DIR/guides/${rel_path}"
+    mkdir -p "$dest_dir"
+
+    # Copy all images from benchmark-results directory
+    find "$bench_dir" -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.svg" -o -name "*.gif" \) -exec cp {} "$dest_dir/" \; 2>/dev/null || true
 done
 
 # === Generate dark mode variants for all SVGs ===
@@ -375,6 +401,18 @@ find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         sed_inplace \
             -e "s|!\[\([^]]*\)\](images/\([^)]*\))|![\1](/img/docs/guides/$guide_subdir/\2)|g" \
             -e "s|!\[\([^]]*\)\](./images/\([^)]*\))|![\1](/img/docs/guides/$guide_subdir/\2)|g" \
+            "$file"
+    fi
+
+    # Convert benchmark-results/ paths to /img/docs/guides/[path]/benchmark-results/
+    # Example: ./benchmark-results/foo.png -> /img/docs/guides/precise-prefix-cache-aware/benchmark-results/foo.png
+    # This handles both <img src="./benchmark-results/..."> and markdown images
+    if [[ "$guide_subdir" != "." ]]; then
+        sed_inplace \
+            -e "s|src=\"\./benchmark-results/\([^\"]*\)\"|src=\"/img/docs/guides/$guide_subdir/benchmark-results/\1\"|g" \
+            -e "s|src=\"benchmark-results/\([^\"]*\)\"|src=\"/img/docs/guides/$guide_subdir/benchmark-results/\1\"|g" \
+            -e "s|!\[\([^]]*\)\](./benchmark-results/\([^)]*\))|![\1](/img/docs/guides/$guide_subdir/benchmark-results/\2)|g" \
+            -e "s|!\[\([^]]*\)\](benchmark-results/\([^)]*\))|![\1](/img/docs/guides/$guide_subdir/benchmark-results/\2)|g" \
             "$file"
     fi
 done

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -339,7 +339,11 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](infra-providers/\([^)]*\))|\](/docs/resources/infra-providers/\1)|g' \
         -e 's|\](/docs/\([^)]*\)/README\.md)|\](/docs/\1)|g' \
         -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](../../guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
         -e 's|\](/docs/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
+        -e 's|\](/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
+        -e 's|\](../../guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
         -e 's|\](../../../../guides/tiered-prefix-cache)|\](/docs/guides/tiered-prefix-cache)|g' \
         -e 's|\](/guides/tiered-prefix-cache)|\](/docs/guides/tiered-prefix-cache)|g' \
         -e 's|\](../../../../guides/batch-gateway)|\](/docs/guides/batch-gateway)|g' \
@@ -513,8 +517,8 @@ fi
 # rdma/rdma-configuration.md comes from resources-new/rdma/README.md
 if [[ -f "$DOCS_DIR/resources/rdma/rdma-configuration.md" ]]; then
     sed_inplace \
-        -e 's|\](../../well-lit-paths/pd-disaggregation\.md)|\](/guides/pd-disaggregation)|g' \
-        -e 's|\](../../well-lit-paths/wide-expert-parallelism\.md)|\](/guides/wide-expert-parallelism)|g' \
+        -e 's|\](../../well-lit-paths/pd-disaggregation\.md)|\](/docs/guides/pd-disaggregation)|g' \
+        -e 's|\](../../well-lit-paths/wide-expert-parallelism\.md)|\](/docs/guides/wide-ep-lws)|g' \
         -e 's|\](../../architecture/core/model-servers\.md)|\](/architecture/core/model-servers)|g' \
         "$DOCS_DIR/resources/rdma/rdma-configuration.md"
 fi

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -147,8 +147,9 @@ cp_doc "$WIP/well-lit-paths/README.md" "$DOCS_DIR/guides/index.md"
 
 sed_inplace \
     -e 's|\](optimized-baseline\.md)|\](/guides/optimized-baseline)|g' \
-    -e 's|\](predicted-latency\.md)|\](/guides/predicted-latency-based-scheduling)|g' \
-    -e 's|\](precise-prefix-cache-aware\.md)|\](/guides/precise-prefix-cache-aware)|g' \
+    -e 's|\](predicted-latency\.md)|\](/guides/predicted-latency-routing)|g' \
+    -e 's|\](precise-prefix-cache-aware\.md)|\](/guides/precise-prefix-cache-routing)|g' \
+    -e 's|\](precise-prefix-cache-routing\.md)|\](/guides/precise-prefix-cache-routing)|g' \
     -e 's|\](tiered-prefix-cache\.md)|\](/guides/tiered-prefix-cache)|g' \
     -e 's|\](pd-disaggregation\.md)|\](/guides/pd-disaggregation)|g' \
     -e 's|\](wide-expert-parallelism\.md)|\](/guides/wide-ep-lws)|g' \
@@ -245,7 +246,8 @@ find "$DOCS_DIR/resources/infra-providers" -name "*.md" -print0 | while IFS= rea
         -e 's|\./images/\([^)]*\)|/img/docs/\1|g' \
         -e 's|](images/\([^)]*\))|](/img/docs/\1)|g' \
         -e 's|\.\./\.\./\.\./guides/optimized-baseline/README\.md|/guides/optimized-baseline|g' \
-        -e 's|\.\./\.\./\.\./guides/precise-prefix-cache-aware/README\.md|/guides/precise-prefix-cache-aware|g' \
+        -e 's|\.\./\.\./\.\./guides/precise-prefix-cache-aware/README\.md|/guides/precise-prefix-cache-routing|g' \
+        -e 's|\.\./\.\./\.\./guides/precise-prefix-cache-routing/README\.md|/guides/precise-prefix-cache-routing|g' \
         -e 's|\.\./\.\./\.\./guides/pd-disaggregation/README\.md|/guides/pd-disaggregation|g' \
         -e 's|\.\./\.\./\.\./guides/wide-ep-lws/README\.md|https://github.com/llm-d/llm-d/tree/main/guides/wide-ep-lws|g' \
         -e 's|\.\./\.\./\.\./guides/tiered-prefix-cache/README\.md|https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache|g' \
@@ -287,9 +289,11 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](/docs/infra-providers)|\](/docs/resources/infra-providers)|g' \
         -e 's|\](infra-providers/\([^)]*\))|\](/resources/infra-providers/\1)|g' \
         -e 's|\](/docs/\([^)]*\)/README\.md)|\](/docs/\1)|g' \
-        -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
-        -e 's|\](/guides/predicted-latency)|\](/guides/predicted-latency-based-scheduling)|g' \
-        -e 's|\](../../guides/predicted-latency)|\](/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](/docs/guides/predicted-latency-based-scheduling)|\](/docs/guides/predicted-latency-routing)|g' \
+        -e 's|\](/guides/predicted-latency-based-scheduling)|\](/guides/predicted-latency-routing)|g' \
+        -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-routing)|g' \
+        -e 's|\](/guides/predicted-latency)|\](/guides/predicted-latency-routing)|g' \
+        -e 's|\](../../guides/predicted-latency)|\](/guides/predicted-latency-routing)|g' \
         -e 's|\](/docs/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
         -e 's|\](/guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \
         -e 's|\](../../guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \
@@ -401,12 +405,18 @@ find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](/docs/guides/tuning\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/flow-control/tuning.md)|g' \
         -e 's|\](./objectives\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/flow-control/objectives.yaml)|g' \
         -e 's|\](/docs/guides/objectives\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/flow-control/objectives.yaml)|g' \
-        -e 's|\](scheduler/precise-prefix-cache-aware\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-aware/scheduler/precise-prefix-cache-aware.values.yaml)|g' \
-        -e 's|\](/docs/guides/scheduler/precise-prefix-cache-aware\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-aware/scheduler/precise-prefix-cache-aware.values.yaml)|g' \
-        -e 's|\](./scheduler/predicted-latency\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml)|g' \
-        -e 's|\](/docs/guides/scheduler/predicted-latency\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml)|g' \
-        -e 's|\](./scheduler/predicted-latency-slo\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml)|g' \
-        -e 's|\](/docs/guides/scheduler/predicted-latency-slo\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml)|g' \
+        -e 's|\](scheduler/precise-prefix-cache-aware\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-routing/scheduler/precise-prefix-cache-aware.values.yaml)|g' \
+        -e 's|\](/docs/guides/scheduler/precise-prefix-cache-aware\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-routing/scheduler/precise-prefix-cache-aware.values.yaml)|g' \
+        -e 's|\](router/precise-prefix-cache-routing\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml)|g' \
+        -e 's|\](/docs/guides/router/precise-prefix-cache-routing\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml)|g' \
+        -e 's|\](./scheduler/predicted-latency\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-routing/scheduler/predicted-latency.values.yaml)|g' \
+        -e 's|\](/docs/guides/scheduler/predicted-latency\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-routing/scheduler/predicted-latency.values.yaml)|g' \
+        -e 's|\](./router/predicted-latency\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-routing/router/predicted-latency.values.yaml)|g' \
+        -e 's|\](/docs/guides/router/predicted-latency\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-routing/router/predicted-latency.values.yaml)|g' \
+        -e 's|\](./scheduler/predicted-latency-slo\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-routing/scheduler/predicted-latency-slo.values.yaml)|g' \
+        -e 's|\](/docs/guides/scheduler/predicted-latency-slo\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-routing/scheduler/predicted-latency-slo.values.yaml)|g' \
+        -e 's|\](./router/predicted-latency-slo\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-routing/router/predicted-latency-slo.values.yaml)|g' \
+        -e 's|\](/docs/guides/router/predicted-latency-slo\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-routing/router/predicted-latency-slo.values.yaml)|g' \
         -e 's|\](./storage_class\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache/storage/manifests/backends/lustre/storage_class.yaml)|g' \
         -e 's|\](/docs/guides/tiered-prefix-cache/storage/manifests/backends/storage_class\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache/storage/manifests/backends/lustre/storage_class.yaml)|g' \
         -e 's|\](./README\.hpa-epp/index\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling)|g' \

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -149,6 +149,20 @@ echo "    Copying well-lit-paths overview pages as fallback..."
 # Copy well-lit-paths overview as top-level guides/index.md
 cp_doc "$WIP/well-lit-paths/README.md" "$DOCS_DIR/guides/index.md"
 
+# Fix guide links in guides/index.md (well-lit-paths uses .md links, need to convert to proper paths)
+sed_inplace \
+    -e 's|\](optimized-baseline\.md)|\](/docs/guides/optimized-baseline)|g' \
+    -e 's|\](predicted-latency\.md)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
+    -e 's|\](precise-prefix-cache-aware\.md)|\](/docs/guides/precise-prefix-cache-aware)|g' \
+    -e 's|\](tiered-prefix-cache\.md)|\](/docs/guides/tiered-prefix-cache)|g' \
+    -e 's|\](pd-disaggregation\.md)|\](/docs/guides/pd-disaggregation)|g' \
+    -e 's|\](wide-expert-parallelism\.md)|\](/docs/guides/wide-ep-lws)|g' \
+    -e 's|\](flow-control\.md)|\](/docs/guides/flow-control)|g' \
+    -e 's|\](workload-autoscaling\.md)|\](/docs/guides/workload-autoscaling)|g' \
+    -e 's|\](asynchronous-processing\.md)|\](/docs/guides/asynchronous-processing)|g' \
+    -e 's|\](experimental/batch-gateway\.md)|\](/docs/guides/batch-gateway)|g' \
+    "$DOCS_DIR/guides/index.md"
+
 # For guides that don't have detailed guides/, copy well-lit-paths overview
 # Only copy if the detailed guide directory doesn't exist
 if [[ ! -d "$SRC/guides/predicted-latency-based-scheduling" ]]; then
@@ -288,31 +302,25 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|advanced/disaggregation\.md|advanced/disaggregation/index.md|g' \
         -e 's|advanced/autoscaling/autoscaling\.md|advanced/autoscaling/index.md|g' \
         -e 's|advanced/batch/README\.md|advanced/batch/index.md|g' \
-        -e 's|\](/guides/README)|\](/guides)|g' \
-        -e 's|\](/experimental/batch-gateway)|\](/guides/experimental/batch-gateway)|g' \
-        -e 's|\](/architecture/core/epp)|\](/architecture/core/router/epp)|g' \
-        -e 's|\](/well-lit-paths/\([^)]*\)\.md)|\](/guides/\1)|g' \
-        -e 's|\](well-lit-paths/\([^)]*\))|\](/guides/\1)|g' \
-        -e 's|\](.*\/guides/tiered-prefix-cache)|\](https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache)|g' \
-        -e 's|\](.*\/guides/batch-gateway)|\](https://github.com/llm-d/llm-d/tree/main/guides/batch-gateway)|g' \
-        -e 's|\](.*\/guides/asynchronous-processing)|\](https://github.com/llm-d/llm-d/tree/main/guides/asynchronous-processing)|g' \
-        -e 's|\](.*\/guides/optimized-baseline)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline)|g' \
-        -e 's|\](.*\/guides/precise-prefix-cache-aware)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-aware)|g' \
-        -e 's|\](.*\/guides/pd-disaggregation)|\](https://github.com/llm-d/llm-d/tree/main/guides/pd-disaggregation)|g' \
-        -e 's|\](.*\/guides/wide-ep-lws)|\](https://github.com/llm-d/llm-d/tree/main/guides/wide-ep-lws)|g' \
-        -e 's|\](.*\/guides/predicted-latency-based-scheduling)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-based-scheduling)|g' \
-        -e 's|\](.*\/guides/workload-autoscaling)|\](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling)|g' \
-        -e 's|\](.*\/guides/flow-control)|\](https://github.com/llm-d/llm-d/tree/main/guides/flow-control)|g' \
-        -e 's|\](/guides/tiered-prefix-cache)|\](https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache)|g' \
-        -e 's|\](/guides/batch-gateway)|\](https://github.com/llm-d/llm-d/tree/main/guides/batch-gateway)|g' \
-        -e 's|\](/guides/asynchronous-processing)|\](https://github.com/llm-d/llm-d/tree/main/guides/asynchronous-processing)|g' \
-        -e 's|\](/guides/optimized-baseline)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline)|g' \
-        -e 's|\](/guides/precise-prefix-cache-aware)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-aware)|g' \
-        -e 's|\](.*\/docs/infra-providers)|\](/resources/infra-providers)|g' \
-        -e 's|\](.*\/infra-providers)|\](/resources/infra-providers)|g' \
-        -e 's|\](/infra-providers)|\](/resources/infra-providers)|g' \
-        -e 's|\](infra-providers/\([^)]*\))|\](/resources/infra-providers/\1)|g' \
-        -e 's|\](/\([^)]*\)/README\.md)|\](/\1)|g' \
+        -e 's|\](/docs/guides/README)|\](/docs/guides)|g' \
+        -e 's|\](/docs/experimental/batch-gateway)|\](/docs/guides/experimental/batch-gateway)|g' \
+        -e 's|\](/docs/architecture/core/epp)|\](/docs/architecture/core/router/epp)|g' \
+        -e 's|\](/docs/well-lit-paths/\([^)]*\)\.md)|\](/docs/guides/\1)|g' \
+        -e 's|\](well-lit-paths/\([^)]*\))|\](/docs/guides/\1)|g' \
+        -e 's|\](.*\/docs/infra-providers)|\](/docs/resources/infra-providers)|g' \
+        -e 's|\](.*\/infra-providers)|\](/docs/resources/infra-providers)|g' \
+        -e 's|\](/docs/infra-providers)|\](/docs/resources/infra-providers)|g' \
+        -e 's|\](infra-providers/\([^)]*\))|\](/docs/resources/infra-providers/\1)|g' \
+        -e 's|\](/docs/\([^)]*\)/README\.md)|\](/docs/\1)|g' \
+        -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](/docs/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
+        -e 's|\](../../../../guides/tiered-prefix-cache)|\](/docs/guides/tiered-prefix-cache)|g' \
+        -e 's|\](/guides/tiered-prefix-cache)|\](/docs/guides/tiered-prefix-cache)|g' \
+        -e 's|\](../../../../guides/batch-gateway)|\](/docs/guides/batch-gateway)|g' \
+        -e 's|\](/guides/batch-gateway)|\](/docs/guides/batch-gateway)|g' \
+        -e 's|\](../../../guides/batch-gateway)|\](/docs/guides/batch-gateway)|g' \
+        -e 's|\](../../../guides/asynchronous-processing)|\](/docs/guides/asynchronous-processing)|g' \
+        -e 's|\](../../guides/pd-disaggregation/README\.md)|\](/docs/guides/pd-disaggregation)|g' \
         "$file"
 done
 
@@ -333,10 +341,27 @@ find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\]\(redis/README\.md\)|\](redis/index.md)|g' \
         -e 's|\]\(./gcp-pubsub/README\.md\)|\](./gcp-pubsub/index.md)|g' \
         -e 's|\]\(./redis/README\.md\)|\](./redis/index.md)|g' \
+        -e 's|\]\(./gcp-pubsub/README\.md#testing\)|\](./gcp-pubsub/index.md#testing)|g' \
+        -e 's|\]\(./redis/README\.md#testing\)|\](./redis/index.md#testing)|g' \
         -e 's|\](../optimized-baseline/README\.md)|\](../optimized-baseline/index.md)|g' \
-        -e 's|\](../prereq/gateway-provider/README\.md)|\](../prereq/gateway-provider/index.md)|g' \
-        -e 's|\](../../prereq/gateway-provider/README\.md)|\](../../prereq/gateway-provider/index.md)|g' \
+        -e 's|\](../prereq/gateway-provider/README\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider)|g' \
+        -e 's|\](../../prereq/gateway-provider/README\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider)|g' \
+        -e 's|\](../prereq/gateway-provider/index\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider)|g' \
+        -e 's|\](../../prereq/gateway-provider/index\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider)|g' \
         -e 's|\](../asynchronous-processing/README\.md)|\](../asynchronous-processing/index.md)|g' \
+        -e 's|\](/docs/guides/cpu/README\.md)|\](/docs/guides/tiered-prefix-cache/cpu)|g' \
+        -e 's|\](/docs/guides/storage/README\.md)|\](/docs/guides/tiered-prefix-cache/storage)|g' \
+        -e 's|\](/docs/guides/redis/README\.md)|\](/docs/guides/asynchronous-processing/redis)|g' \
+        -e 's|\](/docs/guides/gcp-pubsub/README\.md)|\](/docs/guides/asynchronous-processing/gcp-pubsub)|g' \
+        -e 's|\](/docs/guides/README\.md)|\](/docs/guides)|g' \
+        -e 's|\](../README\.md#installation)|\](../index.md#installation)|g' \
+        -e 's|\](../../recipes/gateway/README\.md)|\](/docs/guides/recipes/gateway)|g' \
+        -e 's|\](../gateway)|\](/docs/guides/recipes/gateway)|g' \
+        -e 's|\](/docs/guides/gateway)|\](/docs/guides/recipes/gateway)|g' \
+        -e 's|\](/docs/guides/tiered-prefix-cache/manifests/backends/lustre/README\.md)|\](/docs/guides/tiered-prefix-cache/storage/manifests/backends/lustre)|g' \
+        -e 's|\](/docs/guides/tiered-prefix-cache/manifests/backends/aws/README\.md)|\](/docs/guides/tiered-prefix-cache/storage/manifests/backends/aws)|g' \
+        -e 's|\](./manifests/backends/lustre/README\.md)|\](./manifests/backends/lustre/index.md)|g' \
+        -e 's|\](./manifests/backends/aws/README\.md)|\](./manifests/backends/aws/index.md)|g' \
         "$file"
 
     # Convert relative image paths to local static paths
@@ -352,6 +377,86 @@ find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
             -e "s|!\[\([^]]*\)\](./images/\([^)]*\))|![\1](/img/docs/guides/$guide_subdir/\2)|g" \
             "$file"
     fi
+done
+
+# === Fix prereq and helper references ===
+# We excluded prereq pages, so point to upstream GitHub
+# Helper files don't exist on the site, so point to upstream GitHub
+echo "    Fixing prereq and helper file references..."
+find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
+    sed_inplace \
+        -e 's|\](../prereq/gateways)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateways)|g' \
+        -e 's|\](../../prereq/gateways)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateways)|g' \
+        -e 's|\](/docs/prereq/gateways)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateways)|g' \
+        -e 's|\](/docs/guides/prereq/gateway-provider)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider)|g' \
+        -e 's|\](../../prereq/gateway-provider/README\.md#supported-providers)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider#supported-providers)|g' \
+        -e 's|\](../../prereq/gateway-provider/common-configurations)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider#common-configurations)|g' \
+        -e 's|\](/docs/prereq/gateway-provider/index\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider)|g' \
+        -e 's|\](../../helpers/client-setup/README\.md)|\](https://github.com/llm-d/llm-d/tree/main/helpers/client-setup)|g' \
+        -e 's|\](../../../helpers/client-setup/README\.md)|\](https://github.com/llm-d/llm-d/tree/main/helpers/client-setup)|g' \
+        -e 's|\](/helpers/client-setup/README\.md)|\](https://github.com/llm-d/llm-d/tree/main/helpers/client-setup)|g' \
+        -e 's|\](../../helpers/hf-token\.md)|\](https://github.com/llm-d/llm-d/tree/main/helpers/hf-token.md)|g' \
+        -e 's|\](../../../helpers/hf-token\.md)|\](https://github.com/llm-d/llm-d/tree/main/helpers/hf-token.md)|g' \
+        -e 's|\](/helpers/hf-token\.md)|\](https://github.com/llm-d/llm-d/tree/main/helpers/hf-token.md)|g' \
+        -e 's|\](../../helpers/benchmark\.md)|\](https://github.com/llm-d/llm-d/tree/main/helpers/benchmark.md)|g' \
+        -e 's|\](../../../helpers/benchmark\.md)|\](https://github.com/llm-d/llm-d/tree/main/helpers/benchmark.md)|g' \
+        -e 's|\](/helpers/benchmark\.md)|\](https://github.com/llm-d/llm-d/tree/main/helpers/benchmark.md)|g' \
+        -e 's|\](../../docs/monitoring/README\.md)|\](https://github.com/llm-d/llm-d/tree/main/docs/monitoring)|g' \
+        -e 's|\](../../../docs/monitoring/README\.md)|\](https://github.com/llm-d/llm-d/tree/main/docs/monitoring)|g' \
+        -e 's|\](/docs/monitoring/README\.md)|\](https://github.com/llm-d/llm-d/tree/main/docs/monitoring)|g' \
+        -e 's|\](../../../../../prereq/infrastructure/README\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/infrastructure)|g' \
+        -e 's|\](/docs/prereq/infrastructure/README\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/infrastructure)|g' \
+        "$file"
+done
+
+# === Fix placeholder and missing file references ===
+echo "    Fixing placeholder and missing file references..."
+find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
+    sed_inplace \
+        -e 's|\](placeholder-link)|\](https://github.com/llm-d/llm-d)|g' \
+        -e 's|\](/docs/guides/placeholder-link)|\](https://github.com/llm-d/llm-d)|g' \
+        -e 's|\](tuning\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/flow-control/tuning.md)|g' \
+        -e 's|\](/docs/guides/tuning\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/flow-control/tuning.md)|g' \
+        -e 's|\](./objectives\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/flow-control/objectives.yaml)|g' \
+        -e 's|\](/docs/guides/objectives\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/flow-control/objectives.yaml)|g' \
+        -e 's|\](scheduler/precise-prefix-cache-aware\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-aware/scheduler/precise-prefix-cache-aware.values.yaml)|g' \
+        -e 's|\](/docs/guides/scheduler/precise-prefix-cache-aware\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-aware/scheduler/precise-prefix-cache-aware.values.yaml)|g' \
+        -e 's|\](./scheduler/predicted-latency\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml)|g' \
+        -e 's|\](/docs/guides/scheduler/predicted-latency\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml)|g' \
+        -e 's|\](./scheduler/predicted-latency-slo\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml)|g' \
+        -e 's|\](/docs/guides/scheduler/predicted-latency-slo\.values\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml)|g' \
+        -e 's|\](./storage_class\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache/storage/manifests/backends/lustre/storage_class.yaml)|g' \
+        -e 's|\](/docs/guides/tiered-prefix-cache/storage/manifests/backends/storage_class\.yaml)|\](https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache/storage/manifests/backends/lustre/storage_class.yaml)|g' \
+        -e 's|\](./README\.hpa-epp/index\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling)|g' \
+        -e 's|\](/docs/guides/README\.hpa-epp/index\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling)|g' \
+        -e 's|\](./README\.wva\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling)|g' \
+        -e 's|\](/docs/guides/README\.wva\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling)|g' \
+        -e 's|\](../../04_customizing_a_guide\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/04_customizing_a_guide.md)|g' \
+        -e 's|\](/docs/04_customizing_a_guide\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/04_customizing_a_guide.md)|g' \
+        -e 's|\](../../02_verifying_a_guide\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/02_verifying_a_guide.md)|g' \
+        -e 's|\](/docs/02_verifying_a_guide\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/02_verifying_a_guide.md)|g' \
+        -e 's|\](../../02_verifying_a_guide\.md#following-logs-for-requests)|\](https://github.com/llm-d/llm-d/tree/main/guides/02_verifying_a_guide.md#following-logs-for-requests)|g' \
+        "$file"
+done
+
+# === Fix architecture and other cross-references ===
+echo "    Fixing architecture references..."
+find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
+    sed_inplace \
+        -e 's|\](../../docs/architecture/advanced/latency-predictor\.md)|\](/docs/architecture/advanced/latency-predictor)|g' \
+        -e 's|\](/docs/architecture/advanced/latency-predictor\.md)|\](/docs/architecture/advanced/latency-predictor)|g' \
+        -e 's|\](../../docs/architecture/advanced/latency-predictor\.md#observability)|\](/docs/architecture/advanced/latency-predictor#observability)|g' \
+        -e 's|\](../../docs/architecture/core/router/epp/flow-control\.md)|\](/docs/architecture/core/router/epp/flow-control)|g' \
+        -e 's|\](/docs/architecture/core/router/epp/flow-control\.md)|\](/docs/architecture/core/router/epp/flow-control)|g' \
+        -e 's|\](../../docs/architecture/core/epp/flow-control\.md)|\](/docs/architecture/core/router/epp/flow-control)|g' \
+        -e 's|\](/docs/architecture/core/epp/flow-control\.md)|\](/docs/architecture/core/router/epp/flow-control)|g' \
+        -e 's|\](../optimized-baseline/README\.md#supported-hardware-backends)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline#supported-hardware-backends)|g' \
+        -e 's|\](/docs/optimized-baseline/README\.md#supported-hardware-backends)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline#supported-hardware-backends)|g' \
+        -e 's|\](../optimized-baseline)|\](/docs/guides/optimized-baseline)|g' \
+        -e 's|\](/docs/optimized-baseline)|\](/docs/guides/optimized-baseline)|g' \
+        -e 's|\](../optimized-baseline/README\.md#2-deploy-the-model-server)|\](/docs/guides/optimized-baseline#2-deploy-the-model-server)|g' \
+        -e 's|\](../optimized-baseline/README\.md#3-enable-monitoring-optional)|\](/docs/guides/optimized-baseline#3-enable-monitoring-optional)|g' \
+        "$file"
 done
 
 # === Fix gateway index.md links ===

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -512,19 +512,6 @@ sed_inplace \
     -e 's|\](/architecture/core/epp/README\.md)|\](/architecture/core/router/epp)|g' \
     "$DOCS_DIR/architecture/core/router/index.md"
 
-# === Clean up known issues ===
-sed_inplace '/^NEEDS TO BE REDONE/d' "$DOCS_DIR/architecture/core/router/epp/configuration.md" 2>/dev/null || true
-
-# Fix unclosed <br> tags (MDX requires self-closing tags)
-find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
-    sed_inplace 's|<br>|<br />|g' "$file"
-done
-
-# Fix email addresses in angle brackets (MDX interprets them as HTML tags)
-find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
-    sed_inplace 's|<\([^<>]*@[^<>]*\)>|\1|g' "$file"
-done
-
 # === Apply markdown transformations (shared with test-transformations.sh) ===
 echo "    Applying markdown transformations (callouts, tabs, MDX escaping, well-lit-paths links)..."
 find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -50,8 +50,6 @@ fi
 WIP="$SRC/docs"
 ASSETS="$SRC/docs/assets"
 
-# Directory check no longer needed - docs/ always exists in llm-d/llm-d
-
 echo "    Cleaning docs/ directory..."
 rm -rf "$DOCS_DIR"/*
 
@@ -123,24 +121,12 @@ cp_doc "$WIP/architecture/advanced/batch/batch-gateway.md"    "$DOCS_DIR/archite
 cp_doc "$WIP/architecture/advanced/batch/async-processor.md"  "$DOCS_DIR/architecture/advanced/batch/async-processor.md"
 
 # === Guides ===
-# Strategy: Copy detailed guides from guides/ directory (as index.md)
-# Only use well-lit-paths overviews as fallback for guides without detailed versions
-
 echo "    Copying detailed guide README.md files from guides/..."
 
-# Find and copy all README.md files from guides/, converting them to index.md
-# Exclude prereq and experimental directories
 find "$SRC/guides" -name "README.md" -type f 2>/dev/null | grep -v "/prereq/" | grep -v "/experimental/" | while read -r readme_file; do
-    # Calculate relative path from guides/
     rel_path="${readme_file#$SRC/guides/}"
-
-    # Convert README.md to index.md, preserve directory structure
     dst_path="$DOCS_DIR/guides/${rel_path%README.md}index.md"
-
-    # Create directory if needed
     mkdir -p "$(dirname "$dst_path")"
-
-    # Copy the file
     cp "$readme_file" "$dst_path"
 done
 
@@ -157,46 +143,32 @@ fi
 
 echo "    Copying well-lit-paths overview pages as fallback..."
 
-# Copy well-lit-paths overview as top-level guides/index.md
 cp_doc "$WIP/well-lit-paths/README.md" "$DOCS_DIR/guides/index.md"
 
-# Fix guide links in guides/index.md (well-lit-paths uses .md links, need to convert to proper paths)
 sed_inplace \
-    -e 's|\](optimized-baseline\.md)|\](/docs/guides/optimized-baseline)|g' \
-    -e 's|\](predicted-latency\.md)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
-    -e 's|\](precise-prefix-cache-aware\.md)|\](/docs/guides/precise-prefix-cache-aware)|g' \
-    -e 's|\](tiered-prefix-cache\.md)|\](/docs/guides/tiered-prefix-cache)|g' \
-    -e 's|\](pd-disaggregation\.md)|\](/docs/guides/pd-disaggregation)|g' \
-    -e 's|\](wide-expert-parallelism\.md)|\](/docs/guides/wide-ep-lws)|g' \
-    -e 's|\](flow-control\.md)|\](/docs/guides/flow-control)|g' \
-    -e 's|\](workload-autoscaling\.md)|\](/docs/guides/workload-autoscaling)|g' \
-    -e 's|\](asynchronous-processing\.md)|\](/docs/guides/asynchronous-processing)|g' \
-    -e 's|\](experimental/batch-gateway\.md)|\](/docs/guides/batch-gateway)|g' \
+    -e 's|\](optimized-baseline\.md)|\](/guides/optimized-baseline)|g' \
+    -e 's|\](predicted-latency\.md)|\](/guides/predicted-latency-based-scheduling)|g' \
+    -e 's|\](precise-prefix-cache-aware\.md)|\](/guides/precise-prefix-cache-aware)|g' \
+    -e 's|\](tiered-prefix-cache\.md)|\](/guides/tiered-prefix-cache)|g' \
+    -e 's|\](pd-disaggregation\.md)|\](/guides/pd-disaggregation)|g' \
+    -e 's|\](wide-expert-parallelism\.md)|\](/guides/wide-ep-lws)|g' \
+    -e 's|\](flow-control\.md)|\](/guides/flow-control)|g' \
+    -e 's|\](workload-autoscaling\.md)|\](/guides/workload-autoscaling)|g' \
+    -e 's|\](asynchronous-processing\.md)|\](/guides/asynchronous-processing)|g' \
+    -e 's|\](experimental/batch-gateway\.md)|\](/guides/batch-gateway)|g' \
     "$DOCS_DIR/guides/index.md"
 
-# For guides that don't have detailed guides/, copy well-lit-paths overview
-# Only copy if the detailed guide directory doesn't exist
 if [[ ! -d "$SRC/guides/predicted-latency-based-scheduling" ]]; then
     cp_doc "$WIP/well-lit-paths/predicted-latency.md" "$DOCS_DIR/guides/predicted-latency.md"
 fi
 
-# Experimental guides (these don't have detailed versions in guides/)
-# Excluded per user request:
-# mkdir -p "$DOCS_DIR/guides/experimental"
-# cp_doc "$WIP/well-lit-paths/experimental/batch-gateway.md" "$DOCS_DIR/guides/experimental/batch-gateway.md"
-
-# === Resources (formerly guides) ===
+# === Resources ===
 cp_doc "$WIP/resources/monitoring/metrics.md"               "$DOCS_DIR/resources/monitoring/metrics.md"
 cp_doc "$WIP/resources/monitoring/tracing.md"               "$DOCS_DIR/resources/monitoring/tracing.md"
-# PR #1207 places monitoring under guides/monitoring/ — use as fallback
+
 cp_doc "$WIP/guides/monitoring/metrics.md"                  "$DOCS_DIR/resources/monitoring/metrics.md"
 cp_doc "$WIP/guides/monitoring/tracing.md"                  "$DOCS_DIR/resources/monitoring/tracing.md"
-# PR #1259 moved gateway docs to guides/prereq/gateways/
-# Excluded per user request - prereq pages should not be synced:
-# cp_doc "$SRC/guides/prereq/gateways/README.md"              "$DOCS_DIR/resources/gateway/index.md"
-# cp_doc "$SRC/guides/prereq/gateways/istio.md"               "$DOCS_DIR/resources/gateway/istio.md"
-# cp_doc "$SRC/guides/prereq/gateways/gke.md"                 "$DOCS_DIR/resources/gateway/gke.md"
-# cp_doc "$SRC/guides/prereq/gateways/agentgateway.md"        "$DOCS_DIR/resources/gateway/agentgateway.md"
+
 cp_doc "$WIP/resources/rdma/README.md"                      "$DOCS_DIR/resources/rdma/rdma-configuration.md"
 
 # === Infrastructure Providers ===
@@ -219,17 +191,11 @@ cp_doc "$WIP/api-reference/epp-http-headers.md"      "$DOCS_DIR/api-reference/ep
 
 # === Accelerators ===
 cp_doc "$WIP/accelerators/README.md"                 "$DOCS_DIR/accelerators/index.md"
-
-# Fix accelerators links to infra-providers
 if [[ -f "$DOCS_DIR/accelerators/index.md" ]]; then
     sed_inplace \
         -e 's|\.\./infra-providers/gke/README\.md|/resources/infra-providers/gke|g' \
         "$DOCS_DIR/accelerators/index.md"
 fi
-
-# === Deployment Guides ===
-# Note: Deployment guides live in llm-d/guides/ and are linked via GitHub URLs
-# See transformation section below that converts ../../guides/ links to GitHub
 
 # === Assets ===
 echo "    Copying image assets..."
@@ -245,38 +211,22 @@ cp_doc "$WIP/architecture/advanced/autoscaling/hpa-architecture.svg" "$STATIC_DI
 echo "    Copying infrastructure provider images..."
 find "$WIP/infra-providers" -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.svg" \) -exec cp {} "$STATIC_DIR/" \; 2>/dev/null || true
 
-# Guide images - copy with directory structure preserved
-# Exclude prereq and experimental directories
 echo "    Copying guide images..."
 mkdir -p "$STATIC_DIR/guides"
 find "$SRC/guides" -type d -name "images" 2>/dev/null | grep -v "/prereq/" | grep -v "/experimental/" | while read -r img_dir; do
-    # Calculate relative path from guides/
     rel_path="${img_dir#$SRC/guides/}"
-
-    # Create destination directory structure
     dest_dir="$STATIC_DIR/guides/${rel_path%/images}"
     mkdir -p "$dest_dir"
-
-    # Copy all images from this directory
     find "$img_dir" -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.svg" -o -name "*.gif" \) -exec cp {} "$dest_dir/" \; 2>/dev/null || true
 done
 
-# Guide benchmark-results - copy with directory structure preserved
-# Exclude prereq and experimental directories
 echo "    Copying guide benchmark-results..."
 find "$SRC/guides" -type d -name "benchmark-results" 2>/dev/null | grep -v "/prereq/" | grep -v "/experimental/" | while read -r bench_dir; do
-    # Calculate relative path from guides/
     rel_path="${bench_dir#$SRC/guides/}"
-
-    # Create destination directory structure (e.g., /img/docs/guides/precise-prefix-cache-aware/benchmark-results/)
     dest_dir="$STATIC_DIR/guides/${rel_path}"
     mkdir -p "$dest_dir"
-
-    # Copy all images from benchmark-results directory
     find "$bench_dir" -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.svg" -o -name "*.gif" \) -exec cp {} "$dest_dir/" \; 2>/dev/null || true
 done
-
-# === Generate dark mode variants for all SVGs ===
 
 # === Fix specific image paths for Docusaurus ===
 echo "    Fixing specific image references..."
@@ -287,7 +237,6 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|hpa-architecture.svg|/img/docs/hpa-architecture.svg|g' \
         "$file"
 done
-# Note: Generic ../assets/ paths are handled by apply_transformations() below
 
 # === Fix infra-providers image paths and links ===
 echo "    Fixing infra-providers image paths and cross-references..."
@@ -332,25 +281,25 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](/docs/experimental/batch-gateway)|\](/docs/guides/experimental/batch-gateway)|g' \
         -e 's|\](/docs/architecture/core/epp)|\](/docs/architecture/core/router/epp)|g' \
         -e 's|\](/docs/well-lit-paths/\([^)]*\)\.md)|\](/docs/guides/\1)|g' \
-        -e 's|\](well-lit-paths/\([^)]*\))|\](/docs/guides/\1)|g' \
-        -e 's|\](.*\/docs/infra-providers)|\](/docs/resources/infra-providers)|g' \
-        -e 's|\](.*\/infra-providers)|\](/docs/resources/infra-providers)|g' \
+        -e 's|\](well-lit-paths/\([^)]*\))|\](/guides/\1)|g' \
+        -e 's|\](.*\/docs/infra-providers)|\](/resources/infra-providers)|g' \
+        -e 's|\](.*\/infra-providers)|\](/resources/infra-providers)|g' \
         -e 's|\](/docs/infra-providers)|\](/docs/resources/infra-providers)|g' \
-        -e 's|\](infra-providers/\([^)]*\))|\](/docs/resources/infra-providers/\1)|g' \
+        -e 's|\](infra-providers/\([^)]*\))|\](/resources/infra-providers/\1)|g' \
         -e 's|\](/docs/\([^)]*\)/README\.md)|\](/docs/\1)|g' \
         -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
-        -e 's|\](/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
-        -e 's|\](../../guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](/guides/predicted-latency)|\](/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](../../guides/predicted-latency)|\](/guides/predicted-latency-based-scheduling)|g' \
         -e 's|\](/docs/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
-        -e 's|\](/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
-        -e 's|\](../../guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
-        -e 's|\](../../../../guides/tiered-prefix-cache)|\](/docs/guides/tiered-prefix-cache)|g' \
-        -e 's|\](/guides/tiered-prefix-cache)|\](/docs/guides/tiered-prefix-cache)|g' \
-        -e 's|\](../../../../guides/batch-gateway)|\](/docs/guides/batch-gateway)|g' \
-        -e 's|\](/guides/batch-gateway)|\](/docs/guides/batch-gateway)|g' \
-        -e 's|\](../../../guides/batch-gateway)|\](/docs/guides/batch-gateway)|g' \
-        -e 's|\](../../../guides/asynchronous-processing)|\](/docs/guides/asynchronous-processing)|g' \
-        -e 's|\](../../guides/pd-disaggregation/README\.md)|\](/docs/guides/pd-disaggregation)|g' \
+        -e 's|\](/guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \
+        -e 's|\](../../guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \
+        -e 's|\](../../../../guides/tiered-prefix-cache)|\](/guides/tiered-prefix-cache)|g' \
+        -e 's|\](/guides/tiered-prefix-cache)|\](/guides/tiered-prefix-cache)|g' \
+        -e 's|\](../../../../guides/batch-gateway)|\](/guides/batch-gateway)|g' \
+        -e 's|\](/guides/batch-gateway)|\](/guides/batch-gateway)|g' \
+        -e 's|\](../../../guides/batch-gateway)|\](/guides/batch-gateway)|g' \
+        -e 's|\](../../../guides/asynchronous-processing)|\](/guides/asynchronous-processing)|g' \
+        -e 's|\](../../guides/pd-disaggregation/README\.md)|\](/guides/pd-disaggregation)|g' \
         "$file"
 done
 
@@ -385,8 +334,8 @@ find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](/docs/guides/gcp-pubsub/README\.md)|\](/docs/guides/asynchronous-processing/gcp-pubsub)|g' \
         -e 's|\](/docs/guides/README\.md)|\](/docs/guides)|g' \
         -e 's|\](../README\.md#installation)|\](../index.md#installation)|g' \
-        -e 's|\](../../recipes/gateway/README\.md)|\](/docs/guides/recipes/gateway)|g' \
-        -e 's|\](../gateway)|\](/docs/guides/recipes/gateway)|g' \
+        -e 's|\](../../recipes/gateway/README\.md)|\](/guides/recipes/gateway)|g' \
+        -e 's|\](../gateway)|\](/guides/recipes/gateway)|g' \
         -e 's|\](/docs/guides/gateway)|\](/docs/guides/recipes/gateway)|g' \
         -e 's|\](/docs/guides/tiered-prefix-cache/manifests/backends/lustre/README\.md)|\](/docs/guides/tiered-prefix-cache/storage/manifests/backends/lustre)|g' \
         -e 's|\](/docs/guides/tiered-prefix-cache/manifests/backends/aws/README\.md)|\](/docs/guides/tiered-prefix-cache/storage/manifests/backends/aws)|g' \
@@ -394,13 +343,9 @@ find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](./manifests/backends/aws/README\.md)|\](./manifests/backends/aws/index.md)|g' \
         "$file"
 
-    # Convert relative image paths to local static paths
-    # Calculate relative path from guides/ directory
     rel_from_guides="${file#$DOCS_DIR/guides/}"
     guide_subdir="$(dirname "$rel_from_guides")"
 
-    # Convert images/ or ./images/ paths to /img/docs/guides/[path]/
-    # Example: images/foo.png -> /img/docs/guides/wide-ep-lws/experimental-dp-aware/foo.png
     if [[ "$guide_subdir" != "." ]]; then
         sed_inplace \
             -e "s|!\[\([^]]*\)\](images/\([^)]*\))|![\1](/img/docs/guides/$guide_subdir/\2)|g" \
@@ -408,9 +353,6 @@ find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
             "$file"
     fi
 
-    # Convert benchmark-results/ paths to /img/docs/guides/[path]/benchmark-results/
-    # Example: ./benchmark-results/foo.png -> /img/docs/guides/precise-prefix-cache-aware/benchmark-results/foo.png
-    # This handles both <img src="./benchmark-results/..."> and markdown images
     if [[ "$guide_subdir" != "." ]]; then
         sed_inplace \
             -e "s|src=\"\./benchmark-results/\([^\"]*\)\"|src=\"/img/docs/guides/$guide_subdir/benchmark-results/\1\"|g" \
@@ -422,8 +364,6 @@ find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
 done
 
 # === Fix prereq and helper references ===
-# We excluded prereq pages, so point to upstream GitHub
-# Helper files don't exist on the site, so point to upstream GitHub
 echo "    Fixing prereq and helper file references..."
 find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
     sed_inplace \
@@ -485,19 +425,19 @@ done
 echo "    Fixing architecture references..."
 find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
     sed_inplace \
-        -e 's|\](../../docs/architecture/advanced/latency-predictor\.md)|\](/docs/architecture/advanced/latency-predictor)|g' \
-        -e 's|\](/docs/architecture/advanced/latency-predictor\.md)|\](/docs/architecture/advanced/latency-predictor)|g' \
-        -e 's|\](../../docs/architecture/advanced/latency-predictor\.md#observability)|\](/docs/architecture/advanced/latency-predictor#observability)|g' \
-        -e 's|\](../../docs/architecture/core/router/epp/flow-control\.md)|\](/docs/architecture/core/router/epp/flow-control)|g' \
-        -e 's|\](/docs/architecture/core/router/epp/flow-control\.md)|\](/docs/architecture/core/router/epp/flow-control)|g' \
-        -e 's|\](../../docs/architecture/core/epp/flow-control\.md)|\](/docs/architecture/core/router/epp/flow-control)|g' \
-        -e 's|\](/docs/architecture/core/epp/flow-control\.md)|\](/docs/architecture/core/router/epp/flow-control)|g' \
+        -e 's|\](../../docs/architecture/advanced/latency-predictor\.md)|\](/architecture/advanced/latency-predictor)|g' \
+        -e 's|\](/docs/architecture/advanced/latency-predictor\.md)|\](/architecture/advanced/latency-predictor)|g' \
+        -e 's|\](../../docs/architecture/advanced/latency-predictor\.md#observability)|\](/architecture/advanced/latency-predictor#observability)|g' \
+        -e 's|\](../../docs/architecture/core/router/epp/flow-control\.md)|\](/architecture/core/router/epp/flow-control)|g' \
+        -e 's|\](/docs/architecture/core/router/epp/flow-control\.md)|\](/architecture/core/router/epp/flow-control)|g' \
+        -e 's|\](../../docs/architecture/core/epp/flow-control\.md)|\](/architecture/core/router/epp/flow-control)|g' \
+        -e 's|\](/docs/architecture/core/epp/flow-control\.md)|\](/architecture/core/router/epp/flow-control)|g' \
         -e 's|\](../optimized-baseline/README\.md#supported-hardware-backends)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline#supported-hardware-backends)|g' \
         -e 's|\](/docs/optimized-baseline/README\.md#supported-hardware-backends)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline#supported-hardware-backends)|g' \
-        -e 's|\](../optimized-baseline)|\](/docs/guides/optimized-baseline)|g' \
+        -e 's|\](../optimized-baseline)|\](/guides/optimized-baseline)|g' \
         -e 's|\](/docs/optimized-baseline)|\](/docs/guides/optimized-baseline)|g' \
-        -e 's|\](../optimized-baseline/README\.md#2-deploy-the-model-server)|\](/docs/guides/optimized-baseline#2-deploy-the-model-server)|g' \
-        -e 's|\](../optimized-baseline/README\.md#3-enable-monitoring-optional)|\](/docs/guides/optimized-baseline#3-enable-monitoring-optional)|g' \
+        -e 's|\](../optimized-baseline/README\.md#2-deploy-the-model-server)|\](/guides/optimized-baseline#2-deploy-the-model-server)|g' \
+        -e 's|\](../optimized-baseline/README\.md#3-enable-monitoring-optional)|\](/guides/optimized-baseline#3-enable-monitoring-optional)|g' \
         "$file"
 done
 
@@ -517,8 +457,8 @@ fi
 # rdma/rdma-configuration.md comes from resources-new/rdma/README.md
 if [[ -f "$DOCS_DIR/resources/rdma/rdma-configuration.md" ]]; then
     sed_inplace \
-        -e 's|\](../../well-lit-paths/pd-disaggregation\.md)|\](/docs/guides/pd-disaggregation)|g' \
-        -e 's|\](../../well-lit-paths/wide-expert-parallelism\.md)|\](/docs/guides/wide-ep-lws)|g' \
+        -e 's|\](../../well-lit-paths/pd-disaggregation\.md)|\](/guides/pd-disaggregation)|g' \
+        -e 's|\](../../well-lit-paths/wide-expert-parallelism\.md)|\](/guides/wide-ep-lws)|g' \
         -e 's|\](../../architecture/core/model-servers\.md)|\](/architecture/core/model-servers)|g' \
         "$DOCS_DIR/resources/rdma/rdma-configuration.md"
 fi
@@ -533,8 +473,6 @@ if [[ -f "$DOCS_DIR/resources/monitoring/metrics.md" ]]; then
 fi
 
 # === Fix API reference links ===
-# API reference pages link to each other with .md extensions
-# Convert them to Docusaurus-compatible paths
 echo "    Fixing API reference links..."
 sed_inplace \
     -e 's|\](inferencepool\.md)|\](/api-reference/inferencepool)|g' \
@@ -546,8 +484,6 @@ sed_inplace \
     "$DOCS_DIR/api-reference/index.md"
 
 # === Fix architecture index.md relative paths ===
-# When architecture/README.md becomes index.md, relative paths break
-# Convert ./core/* and ./advanced/* to absolute paths with /architecture/ prefix
 echo "    Fixing architecture index.md relative paths..."
 sed_inplace \
     -e 's|\(\[.*\]\)(\./core/inferencepool)|\1(/architecture/core/inferencepool)|g' \
@@ -569,7 +505,6 @@ sed_inplace \
     "$DOCS_DIR/architecture/index.md"
 
 # === Fix router index.md relative paths ===
-# Similar issue with router/index.md
 sed_inplace \
     -e 's|\](\.\/epp/)|\](/architecture/core/router/epp)|g' \
     -e 's|\](\.\/epp)|\](/architecture/core/router/epp)|g' \
@@ -578,7 +513,6 @@ sed_inplace \
     "$DOCS_DIR/architecture/core/router/index.md"
 
 # === Clean up known issues ===
-# Remove "NEEDS TO BE REDONE" from configuration.md
 sed_inplace '/^NEEDS TO BE REDONE/d' "$DOCS_DIR/architecture/core/router/epp/configuration.md" 2>/dev/null || true
 
 # Fix unclosed <br> tags (MDX requires self-closing tags)
@@ -587,7 +521,6 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
 done
 
 # Fix email addresses in angle brackets (MDX interprets them as HTML tags)
-# Replace <email@domain.com> with email@domain.com
 find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
     sed_inplace 's|<\([^<>]*@[^<>]*\)>|\1|g' "$file"
 done
@@ -606,8 +539,6 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
     sed_inplace 's|/img/docs/images/|/img/docs/|g' "$file"
 done
 
-# === Convert SVG images to theme-aware dual images ===
-
 # === Generate stubs for pages in outline that don't have source content yet ===
 echo "    Generating stubs for missing pages..."
 
@@ -616,7 +547,6 @@ generate_stub() {
     local title="$2"
     local desc="$3"
 
-    # Only create if doesn't exist or is empty
     if [[ ! -s "$filepath" ]]; then
         cat > "$filepath" << STUBEOF
 ---
@@ -632,10 +562,6 @@ This page is under active development. Content coming soon.
 STUBEOF
     fi
 }
-
-# Guides stubs - NO LONGER NEEDED
-# Detailed guides are now synced from guides/ directory as index.md files
-# Stub generation would create duplicate routes (.md and /index.md)
 
 # Resources stubs
 generate_stub "$DOCS_DIR/resources/gateway/index.md" "Gateway" "Gateway deployment and configuration guides"

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -122,22 +122,43 @@ cp_doc "$WIP/architecture/advanced/batch/README.md"           "$DOCS_DIR/archite
 cp_doc "$WIP/architecture/advanced/batch/batch-gateway.md"    "$DOCS_DIR/architecture/advanced/batch/batch-gateway.md"
 cp_doc "$WIP/architecture/advanced/batch/async-processor.md"  "$DOCS_DIR/architecture/advanced/batch/async-processor.md"
 
-# === Guides (from well-lit-paths directory) ===
-# Copy exactly what exists in source repo
-cp_doc "$WIP/well-lit-paths/README.md"                    "$DOCS_DIR/guides/index.md"
-cp_doc "$WIP/well-lit-paths/optimized-baseline.md"        "$DOCS_DIR/guides/optimized-baseline.md"
-cp_doc "$WIP/well-lit-paths/precise-prefix-cache-aware.md" "$DOCS_DIR/guides/precise-prefix-cache-aware.md"
-cp_doc "$WIP/well-lit-paths/tiered-prefix-cache.md"       "$DOCS_DIR/guides/tiered-prefix-cache.md"
-cp_doc "$WIP/well-lit-paths/asynchronous-processing.md"   "$DOCS_DIR/guides/asynchronous-processing.md"
-cp_doc "$WIP/well-lit-paths/flow-control.md"              "$DOCS_DIR/guides/flow-control.md"
-cp_doc "$WIP/well-lit-paths/pd-disaggregation.md"         "$DOCS_DIR/guides/pd-disaggregation.md"
-cp_doc "$WIP/well-lit-paths/predicted-latency.md"         "$DOCS_DIR/guides/predicted-latency.md"
-cp_doc "$WIP/well-lit-paths/wide-expert-parallelism.md"   "$DOCS_DIR/guides/wide-expert-parallelism.md"
-cp_doc "$WIP/well-lit-paths/workload-autoscaling.md"      "$DOCS_DIR/guides/workload-autoscaling.md"
+# === Guides ===
+# Strategy: Copy detailed guides from guides/ directory (as index.md)
+# Only use well-lit-paths overviews as fallback for guides without detailed versions
 
-# Experimental guides
-mkdir -p "$DOCS_DIR/guides/experimental"
-cp_doc "$WIP/well-lit-paths/experimental/batch-gateway.md" "$DOCS_DIR/guides/experimental/batch-gateway.md"
+echo "    Copying detailed guide README.md files from guides/..."
+
+# Find and copy all README.md files from guides/, converting them to index.md
+# Exclude prereq and experimental directories
+find "$SRC/guides" -name "README.md" -type f 2>/dev/null | grep -v "/prereq/" | grep -v "/experimental/" | while read -r readme_file; do
+    # Calculate relative path from guides/
+    rel_path="${readme_file#$SRC/guides/}"
+
+    # Convert README.md to index.md, preserve directory structure
+    dst_path="$DOCS_DIR/guides/${rel_path%README.md}index.md"
+
+    # Create directory if needed
+    mkdir -p "$(dirname "$dst_path")"
+
+    # Copy the file
+    cp "$readme_file" "$dst_path"
+done
+
+echo "    Copying well-lit-paths overview pages as fallback..."
+
+# Copy well-lit-paths overview as top-level guides/index.md
+cp_doc "$WIP/well-lit-paths/README.md" "$DOCS_DIR/guides/index.md"
+
+# For guides that don't have detailed guides/, copy well-lit-paths overview
+# Only copy if the detailed guide directory doesn't exist
+if [[ ! -d "$SRC/guides/predicted-latency-based-scheduling" ]]; then
+    cp_doc "$WIP/well-lit-paths/predicted-latency.md" "$DOCS_DIR/guides/predicted-latency.md"
+fi
+
+# Experimental guides (these don't have detailed versions in guides/)
+# Excluded per user request:
+# mkdir -p "$DOCS_DIR/guides/experimental"
+# cp_doc "$WIP/well-lit-paths/experimental/batch-gateway.md" "$DOCS_DIR/guides/experimental/batch-gateway.md"
 
 # === Resources (formerly guides) ===
 cp_doc "$WIP/resources/monitoring/metrics.md"               "$DOCS_DIR/resources/monitoring/metrics.md"
@@ -146,10 +167,11 @@ cp_doc "$WIP/resources/monitoring/tracing.md"               "$DOCS_DIR/resources
 cp_doc "$WIP/guides/monitoring/metrics.md"                  "$DOCS_DIR/resources/monitoring/metrics.md"
 cp_doc "$WIP/guides/monitoring/tracing.md"                  "$DOCS_DIR/resources/monitoring/tracing.md"
 # PR #1259 moved gateway docs to guides/prereq/gateways/
-cp_doc "$SRC/guides/prereq/gateways/README.md"              "$DOCS_DIR/resources/gateway/index.md"
-cp_doc "$SRC/guides/prereq/gateways/istio.md"               "$DOCS_DIR/resources/gateway/istio.md"
-cp_doc "$SRC/guides/prereq/gateways/gke.md"                 "$DOCS_DIR/resources/gateway/gke.md"
-cp_doc "$SRC/guides/prereq/gateways/agentgateway.md"        "$DOCS_DIR/resources/gateway/agentgateway.md"
+# Excluded per user request - prereq pages should not be synced:
+# cp_doc "$SRC/guides/prereq/gateways/README.md"              "$DOCS_DIR/resources/gateway/index.md"
+# cp_doc "$SRC/guides/prereq/gateways/istio.md"               "$DOCS_DIR/resources/gateway/istio.md"
+# cp_doc "$SRC/guides/prereq/gateways/gke.md"                 "$DOCS_DIR/resources/gateway/gke.md"
+# cp_doc "$SRC/guides/prereq/gateways/agentgateway.md"        "$DOCS_DIR/resources/gateway/agentgateway.md"
 cp_doc "$WIP/resources/rdma/README.md"                      "$DOCS_DIR/resources/rdma/rdma-configuration.md"
 
 # === Infrastructure Providers ===
@@ -197,6 +219,22 @@ cp_doc "$WIP/architecture/advanced/autoscaling/hpa-architecture.svg" "$STATIC_DI
 # Infrastructure Providers images
 echo "    Copying infrastructure provider images..."
 find "$WIP/infra-providers" -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.svg" \) -exec cp {} "$STATIC_DIR/" \; 2>/dev/null || true
+
+# Guide images - copy with directory structure preserved
+# Exclude prereq and experimental directories
+echo "    Copying guide images..."
+mkdir -p "$STATIC_DIR/guides"
+find "$SRC/guides" -type d -name "images" 2>/dev/null | grep -v "/prereq/" | grep -v "/experimental/" | while read -r img_dir; do
+    # Calculate relative path from guides/
+    rel_path="${img_dir#$SRC/guides/}"
+
+    # Create destination directory structure
+    dest_dir="$STATIC_DIR/guides/${rel_path%/images}"
+    mkdir -p "$dest_dir"
+
+    # Copy all images from this directory
+    find "$img_dir" -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.svg" -o -name "*.gif" \) -exec cp {} "$dest_dir/" \; 2>/dev/null || true
+done
 
 # === Generate dark mode variants for all SVGs ===
 
@@ -276,6 +314,44 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](infra-providers/\([^)]*\))|\](/resources/infra-providers/\1)|g' \
         -e 's|\](/\([^)]*\)/README\.md)|\](/\1)|g' \
         "$file"
+done
+
+# === Fix guide internal cross-references ===
+# Guides contain relative links to README.md files that need to be converted to index.md
+echo "    Fixing guide internal cross-references..."
+find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
+    sed_inplace \
+        -e 's|\](README\.md)|\](index.md)|g' \
+        -e 's|\](./README\.md)|\](./index.md)|g' \
+        -e 's|\](../README\.md)|\](../index.md)|g' \
+        -e 's|\](../../README\.md)|\](../../index.md)|g' \
+        -e 's|\](../../../README\.md)|\](../index.md)|g' \
+        -e 's|\](../../../../README\.md)|\](../../index.md)|g' \
+        -e 's|\]\(cpu/README\.md\)|\](cpu/index.md)|g' \
+        -e 's|\]\(storage/README\.md\)|\](storage/index.md)|g' \
+        -e 's|\]\(gcp-pubsub/README\.md\)|\](gcp-pubsub/index.md)|g' \
+        -e 's|\]\(redis/README\.md\)|\](redis/index.md)|g' \
+        -e 's|\]\(./gcp-pubsub/README\.md\)|\](./gcp-pubsub/index.md)|g' \
+        -e 's|\]\(./redis/README\.md\)|\](./redis/index.md)|g' \
+        -e 's|\](../optimized-baseline/README\.md)|\](../optimized-baseline/index.md)|g' \
+        -e 's|\](../prereq/gateway-provider/README\.md)|\](../prereq/gateway-provider/index.md)|g' \
+        -e 's|\](../../prereq/gateway-provider/README\.md)|\](../../prereq/gateway-provider/index.md)|g' \
+        -e 's|\](../asynchronous-processing/README\.md)|\](../asynchronous-processing/index.md)|g' \
+        "$file"
+
+    # Convert relative image paths to local static paths
+    # Calculate relative path from guides/ directory
+    rel_from_guides="${file#$DOCS_DIR/guides/}"
+    guide_subdir="$(dirname "$rel_from_guides")"
+
+    # Convert images/ or ./images/ paths to /img/docs/guides/[path]/
+    # Example: images/foo.png -> /img/docs/guides/wide-ep-lws/experimental-dp-aware/foo.png
+    if [[ "$guide_subdir" != "." ]]; then
+        sed_inplace \
+            -e "s|!\[\([^]]*\)\](images/\([^)]*\))|![\1](/img/docs/guides/$guide_subdir/\2)|g" \
+            -e "s|!\[\([^]]*\)\](./images/\([^)]*\))|![\1](/img/docs/guides/$guide_subdir/\2)|g" \
+            "$file"
+    fi
 done
 
 # === Fix gateway index.md links ===
@@ -410,17 +486,9 @@ STUBEOF
     fi
 }
 
-# Guides stubs (only for files that exist in source repo)
-generate_stub "$DOCS_DIR/guides/index.md" "Guides" "Well-lit paths for production deployments"
-generate_stub "$DOCS_DIR/guides/optimized-baseline.md" "Optimized Baseline" "Baseline deployment with intelligent routing"
-generate_stub "$DOCS_DIR/guides/precise-prefix-cache-aware.md" "Precise Prefix Cache Aware" "Prefix-aware routing configuration"
-generate_stub "$DOCS_DIR/guides/tiered-prefix-cache.md" "Tiered Prefix Cache" "Multi-tier KV cache management"
-generate_stub "$DOCS_DIR/guides/asynchronous-processing.md" "Asynchronous Processing" "Batch and async inference workflows"
-generate_stub "$DOCS_DIR/guides/flow-control.md" "Flow Control" "Admission control and queuing"
-generate_stub "$DOCS_DIR/guides/pd-disaggregation.md" "Prefill/Decode Disaggregation" "Separating prefill and decode phases"
-generate_stub "$DOCS_DIR/guides/predicted-latency.md" "Predicted Latency" "ML-based latency prediction"
-generate_stub "$DOCS_DIR/guides/wide-expert-parallelism.md" "Wide Expert Parallelism" "MoE models with expert parallelism"
-generate_stub "$DOCS_DIR/guides/workload-autoscaling.md" "Workload Autoscaling" "Configuring autoscaling for inference workloads"
+# Guides stubs - NO LONGER NEEDED
+# Detailed guides are now synced from guides/ directory as index.md files
+# Stub generation would create duplicate routes (.md and /index.md)
 
 # Resources stubs
 generate_stub "$DOCS_DIR/resources/gateway/index.md" "Gateway" "Gateway deployment and configuration guides"

--- a/preview/scripts/test-fixtures/transformation-test.expected.md
+++ b/preview/scripts/test-fixtures/transformation-test.expected.md
@@ -1,6 +1,3 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Transformation Test Document
 
 This document contains examples of all markdown transformations that should occur during the sync process.
@@ -43,10 +40,9 @@ All lines should be included in the transformation.
 
 ## 3. Custom Tabs Test
 
+{/* TABS:START */}
 
-<Tabs>
-
-<TabItem value="first-tab" label="First Tab" default>
+{/* TAB:First Tab:default */}
 ### First Tab Content
 
 This is the content of the first tab.
@@ -56,8 +52,7 @@ It should be marked as default.
 echo "First tab code block"
 ```
 
-</TabItem>
-<TabItem value="second-tab" label="Second Tab">
+{/* TAB:Second Tab */}
 ### Second Tab Content
 
 This is the content of the second tab.
@@ -66,23 +61,19 @@ This is the content of the second tab.
 - List item 2
 - List item 3
 
-</TabItem>
-<TabItem value="third-tab-complex-name" label="Third Tab (Complex Name)">
+{/* TAB:Third Tab (Complex Name) */}
 ### Third Tab with Complex Name
 
 This tab has parentheses and spaces in the label.
 The value should be `third-tab-complex-name`.
 
-</TabItem>
-</Tabs>
-
+{/* TABS:END */}
 
 ## 4. Nested Content in Tabs Test
 
+{/* TABS:START */}
 
-<Tabs>
-
-<TabItem value="aws-eks" label="AWS EKS" default>
+{/* TAB:AWS EKS:default */}
 #### Deploy on AWS
 
 ```yaml
@@ -99,17 +90,14 @@ This note is inside a tab!
 :::
 
 
-</TabItem>
-<TabItem value="google-gke" label="Google GKE">
+{/* TAB:Google GKE */}
 #### Deploy on GKE
 
 ```bash
 gcloud container clusters create my-cluster
 ```
 
-</TabItem>
-</Tabs>
-
+{/* TABS:END */}
 
 ## 5. Image Path Test
 
@@ -170,42 +158,32 @@ const test = "value";
 
 ### Empty Tab
 
+{/* TABS:START */}
 
-<Tabs>
+{/* TAB:Empty Tab:default */}
 
-<TabItem value="empty-tab" label="Empty Tab" default>
-
-</TabItem>
-</Tabs>
-
+{/* TABS:END */}
 
 ### Single Tab
 
+{/* TABS:START */}
 
-<Tabs>
-
-<TabItem value="only-tab" label="Only Tab" default>
+{/* TAB:Only Tab:default */}
 This is the only tab.
 
-</TabItem>
-</Tabs>
-
+{/* TABS:END */}
 
 ### Tab with Special Characters
 
+{/* TABS:START */}
 
-<Tabs>
-
-<TabItem value="gke-h100-h200" label="GKE (H100/H200)" default>
+{/* TAB:GKE (H100/H200):default */}
 Content for H100/H200 GPUs.
 
-</TabItem>
-<TabItem value="coreweave-us-east" label="CoreWeave @ US-East">
+{/* TAB:CoreWeave @ US-East */}
 Content with @ symbol.
 
-</TabItem>
-</Tabs>
-
+{/* TABS:END */}
 
 ## 10. Well-Lit Paths Link Transformations
 

--- a/preview/scripts/test-fixtures/transformation-test.expected.md
+++ b/preview/scripts/test-fixtures/transformation-test.expected.md
@@ -1,3 +1,6 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Transformation Test Document
 
 This document contains examples of all markdown transformations that should occur during the sync process.
@@ -40,9 +43,10 @@ All lines should be included in the transformation.
 
 ## 3. Custom Tabs Test
 
-{/* TABS:START */}
 
-{/* TAB:First Tab:default */}
+<Tabs>
+
+<TabItem value="first-tab" label="First Tab" default>
 ### First Tab Content
 
 This is the content of the first tab.
@@ -52,7 +56,8 @@ It should be marked as default.
 echo "First tab code block"
 ```
 
-{/* TAB:Second Tab */}
+</TabItem>
+<TabItem value="second-tab" label="Second Tab">
 ### Second Tab Content
 
 This is the content of the second tab.
@@ -61,19 +66,23 @@ This is the content of the second tab.
 - List item 2
 - List item 3
 
-{/* TAB:Third Tab (Complex Name) */}
+</TabItem>
+<TabItem value="third-tab-complex-name" label="Third Tab (Complex Name)">
 ### Third Tab with Complex Name
 
 This tab has parentheses and spaces in the label.
 The value should be `third-tab-complex-name`.
 
-{/* TABS:END */}
+</TabItem>
+</Tabs>
+
 
 ## 4. Nested Content in Tabs Test
 
-{/* TABS:START */}
 
-{/* TAB:AWS EKS:default */}
+<Tabs>
+
+<TabItem value="aws-eks" label="AWS EKS" default>
 #### Deploy on AWS
 
 ```yaml
@@ -90,14 +99,17 @@ This note is inside a tab!
 :::
 
 
-{/* TAB:Google GKE */}
+</TabItem>
+<TabItem value="google-gke" label="Google GKE">
 #### Deploy on GKE
 
 ```bash
 gcloud container clusters create my-cluster
 ```
 
-{/* TABS:END */}
+</TabItem>
+</Tabs>
+
 
 ## 5. Image Path Test
 
@@ -158,32 +170,42 @@ const test = "value";
 
 ### Empty Tab
 
-{/* TABS:START */}
 
-{/* TAB:Empty Tab:default */}
+<Tabs>
 
-{/* TABS:END */}
+<TabItem value="empty-tab" label="Empty Tab" default>
+
+</TabItem>
+</Tabs>
+
 
 ### Single Tab
 
-{/* TABS:START */}
 
-{/* TAB:Only Tab:default */}
+<Tabs>
+
+<TabItem value="only-tab" label="Only Tab" default>
 This is the only tab.
 
-{/* TABS:END */}
+</TabItem>
+</Tabs>
+
 
 ### Tab with Special Characters
 
-{/* TABS:START */}
 
-{/* TAB:GKE (H100/H200):default */}
+<Tabs>
+
+<TabItem value="gke-h100-h200" label="GKE (H100/H200)" default>
 Content for H100/H200 GPUs.
 
-{/* TAB:CoreWeave @ US-East */}
+</TabItem>
+<TabItem value="coreweave-us-east" label="CoreWeave @ US-East">
 Content with @ symbol.
 
-{/* TABS:END */}
+</TabItem>
+</Tabs>
+
 
 ## 10. Well-Lit Paths Link Transformations
 

--- a/preview/scripts/transformations.sh
+++ b/preview/scripts/transformations.sh
@@ -45,7 +45,9 @@ apply_transformations() {
     # Replace HTML comments with MDX comments: <!-- text --> becomes {/* text */}
     # Handle both single-line and multi-line comments
     # Use perl for multi-line regex support
-    perl -i -pe 'BEGIN{undef $/;} s/<!--(.*?)-->/{\/\*$1\*\/}/gs' "$file"
+    # IMPORTANT: Exclude tab markers (<!-- TABS:START -->, <!-- TAB:... -->, <!-- TABS:END -->)
+    # which need to be processed by the tab transformation later
+    perl -i -pe 'BEGIN{undef $/;} s/<!--(?!\s*TABS?:)(.*?)-->/{\/\*$1\*\/}/gs' "$file"
 
     # Escape angle brackets that look like HTML tags but aren't (e.g., <your_gateway_choice>)
     # These appear in template/placeholder text and confuse MDX parser

--- a/preview/scripts/transformations.sh
+++ b/preview/scripts/transformations.sh
@@ -41,6 +41,23 @@ apply_transformations() {
     # MDX escaping - escape special characters
     sed_inplace 's|<->|\\<->|g' "$file"
 
+    # Escape HTML comments for MDX (MDX doesn't support <!-- --> syntax)
+    # Replace HTML comments with MDX comments: <!-- text --> becomes {/* text */}
+    # Handle both single-line and multi-line comments
+    # Use perl for multi-line regex support
+    perl -i -pe 'BEGIN{undef $/;} s/<!--(.*?)-->/{\/\*$1\*\/}/gs' "$file"
+
+    # Escape angle brackets that look like HTML tags but aren't (e.g., <your_gateway_choice>)
+    # These appear in template/placeholder text and confuse MDX parser
+    # Only escape patterns with underscores or specific placeholder patterns
+    # Don't escape real HTML tags (picture, source, img, div, p, etc.)
+    sed_inplace 's|<\([a-z][a-z0-9]*_[a-z0-9_]*\)>|\\<\1\\>|g' "$file"
+
+    # Escape comparison operators in text (<=, >=) that MDX interprets as JSX
+    # Replace with HTML entities
+    sed_inplace 's|<=|\\&le;|g' "$file"
+    sed_inplace 's|>=|\\&ge;|g' "$file"
+
     # Fix escaped curly braces in tables (MDX interprets \{var\} as JS expression)
     # Convert \{key,value\} -> (key,value) for MDX compatibility
     sed_inplace 's|\\{|(|g' "$file"

--- a/preview/scripts/transformations.sh
+++ b/preview/scripts/transformations.sh
@@ -107,9 +107,9 @@ apply_transformations() {
 
     # Fix guide name variations and relative paths
     sed_inplace \
-        -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
-        -e 's|\](/guides/predicted-latency)|\](/guides/predicted-latency-based-scheduling)|g' \
-        -e 's|\](../../guides/predicted-latency)|\](/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-routing)|g' \
+        -e 's|\](/guides/predicted-latency)|\](/guides/predicted-latency-routing)|g' \
+        -e 's|\](../../guides/predicted-latency)|\](/guides/predicted-latency-routing)|g' \
         -e 's|\](/docs/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
         -e 's|\](/guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \
         -e 's|\](../../guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \

--- a/preview/scripts/transformations.sh
+++ b/preview/scripts/transformations.sh
@@ -108,13 +108,13 @@ apply_transformations() {
     # Fix guide name variations and relative paths
     sed_inplace \
         -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
-        -e 's|\](/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
-        -e 's|\](../../guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](/guides/predicted-latency)|\](/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](../../guides/predicted-latency)|\](/guides/predicted-latency-based-scheduling)|g' \
         -e 's|\](/docs/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
-        -e 's|\](/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
-        -e 's|\](../../guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
+        -e 's|\](/guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \
+        -e 's|\](../../guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \
         -e 's|\](../../prereq/gateway-provider/common-configurations/*)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider#common-configurations)|g' \
-        -e 's|\](../gateway/*)|\](/docs/guides/recipes/gateway)|g' \
+        -e 's|\](../gateway/*)|\](/guides/recipes/gateway)|g' \
         "$file"
 
     # Fix deployment guide links to GitHub URLs

--- a/preview/scripts/transformations.sh
+++ b/preview/scripts/transformations.sh
@@ -108,7 +108,11 @@ apply_transformations() {
     # Fix guide name variations and relative paths
     sed_inplace \
         -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](../../guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
         -e 's|\](/docs/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
+        -e 's|\](/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
+        -e 's|\](../../guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
         -e 's|\](../../prereq/gateway-provider/common-configurations/*)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider#common-configurations)|g' \
         -e 's|\](../gateway/*)|\](/docs/guides/recipes/gateway)|g' \
         "$file"

--- a/preview/scripts/transformations.sh
+++ b/preview/scripts/transformations.sh
@@ -93,6 +93,24 @@ apply_transformations() {
         -e 's|\](/guides/README)|\](/guides)|g' \
         "$file"
 
+    # Fix relative README.md links in guides
+    sed_inplace \
+        -e 's|\](./gcp-pubsub/README\.md)|\](./gcp-pubsub/index.md)|g' \
+        -e 's|\](./redis/README\.md)|\](./redis/index.md)|g' \
+        -e 's|\](./gcp-pubsub/README\.md#testing)|\](./gcp-pubsub/index.md#testing)|g' \
+        -e 's|\](./redis/README\.md#testing)|\](./redis/index.md#testing)|g' \
+        -e 's|\](./cpu/README\.md)|\](./cpu/index.md)|g' \
+        -e 's|\](./storage/README\.md)|\](./storage/index.md)|g' \
+        "$file"
+
+    # Fix guide name variations and relative paths
+    sed_inplace \
+        -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-based-scheduling)|g' \
+        -e 's|\](/docs/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
+        -e 's|\](../../prereq/gateway-provider/common-configurations/*)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider#common-configurations)|g' \
+        -e 's|\](../gateway/*)|\](/docs/guides/recipes/gateway)|g' \
+        "$file"
+
     # Fix deployment guide links to GitHub URLs
     # These guides live in llm-d/guides/ and should link to GitHub
     sed_inplace \

--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -107,15 +107,88 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       link: {type: 'doc', id: 'guides/index'},
       items: [
-        'guides/optimized-baseline',
-        'guides/precise-prefix-cache-aware',
-        'guides/tiered-prefix-cache',
-        'guides/asynchronous-processing',
-        'guides/flow-control',
-        'guides/pd-disaggregation',
-        'guides/predicted-latency',
-        'guides/wide-expert-parallelism',
-        'guides/workload-autoscaling',
+        {
+          type: 'category',
+          label: 'Optimized Baseline',
+          link: {type: 'doc', id: 'guides/optimized-baseline/index'},
+          items: [],
+        },
+        {
+          type: 'category',
+          label: 'Precise Prefix Cache Aware',
+          link: {type: 'doc', id: 'guides/precise-prefix-cache-aware/index'},
+          items: [],
+        },
+        {
+          type: 'category',
+          label: 'Tiered Prefix Cache',
+          link: {type: 'doc', id: 'guides/tiered-prefix-cache/index'},
+          items: [
+            'guides/tiered-prefix-cache/cpu/index',
+            {
+              type: 'category',
+              label: 'Storage Offloading',
+              link: {type: 'doc', id: 'guides/tiered-prefix-cache/storage/index'},
+              items: [
+                'guides/tiered-prefix-cache/storage/manifests/backends/lustre/index',
+                'guides/tiered-prefix-cache/storage/manifests/backends/aws/index',
+              ],
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Asynchronous Processing',
+          link: {type: 'doc', id: 'guides/asynchronous-processing/index'},
+          items: [
+            'guides/asynchronous-processing/gcp-pubsub/index',
+            'guides/asynchronous-processing/redis/index',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Flow Control',
+          link: {type: 'doc', id: 'guides/flow-control/index'},
+          items: [],
+        },
+        {
+          type: 'category',
+          label: 'Prefill/Decode Disaggregation',
+          link: {type: 'doc', id: 'guides/pd-disaggregation/index'},
+          items: [],
+        },
+        'guides/predicted-latency-based-scheduling/index',
+        {
+          type: 'category',
+          label: 'Wide Expert Parallelism',
+          link: {type: 'doc', id: 'guides/wide-ep-lws/index'},
+          items: [
+            {
+              type: 'category',
+              label: 'Experimental DP-Aware',
+              link: {type: 'doc', id: 'guides/wide-ep-lws/experimental-dp-aware/index'},
+              items: [
+                'guides/wide-ep-lws/experimental-dp-aware/benchmarks/index',
+              ],
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Workload Autoscaling',
+          link: {type: 'doc', id: 'guides/workload-autoscaling/index'},
+          items: [],
+        },
+        'guides/batch-gateway/index',
+        {
+          type: 'category',
+          label: 'Recipes',
+          items: [
+            'guides/recipes/gateway/index',
+            'guides/recipes/scheduler/index',
+            'guides/recipes/modelserver/components/disable-gke-nccl-tuner-patch/index',
+          ],
+        },
       ],
     },
     // ==================== Resources ====================

--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -115,8 +115,8 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
-          label: 'Precise Prefix Cache Aware',
-          link: {type: 'doc', id: 'guides/precise-prefix-cache-aware/index'},
+          label: 'Precise Prefix Cache Routing',
+          link: {type: 'doc', id: 'guides/precise-prefix-cache-routing/index'},
           items: [],
         },
         {
@@ -157,7 +157,7 @@ const sidebars: SidebarsConfig = {
           link: {type: 'doc', id: 'guides/pd-disaggregation/index'},
           items: [],
         },
-        'guides/predicted-latency-based-scheduling/index',
+        'guides/predicted-latency-routing/index',
         {
           type: 'category',
           label: 'Wide Expert Parallelism',
@@ -185,7 +185,7 @@ const sidebars: SidebarsConfig = {
           label: 'Recipes',
           items: [
             'guides/recipes/gateway/index',
-            'guides/recipes/scheduler/index',
+            'guides/recipes/router/index',
             'guides/recipes/modelserver/components/disable-gke-nccl-tuner-patch/index',
           ],
         },

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -564,6 +564,25 @@ function normalizeUrl(url, baseUrl) {
   }
 }
 
+// Auto-detect versioned doc paths from the build output.
+// Any directory under build/docs/ matching a version pattern (e.g. 0.7.0, 1.0.0-rc1)
+// is a Docusaurus versioned snapshot and its links are historical — skip them.
+function detectVersionedPaths(buildDir) {
+  const docsDir = path.join(buildDir, 'docs');
+  if (!fs.existsSync(docsDir)) return [];
+
+  const versionPattern = /^\d+\.\d+/;
+  return fs.readdirSync(docsDir)
+    .filter(entry => {
+      try {
+        return fs.statSync(path.join(docsDir, entry)).isDirectory() && versionPattern.test(entry);
+      } catch {
+        return false;
+      }
+    })
+    .map(version => `/docs/${version}/`);
+}
+
 // Main link checking logic
 async function checkLinks() {
   console.log('🔍 Link Checker Starting...\n');
@@ -576,6 +595,15 @@ async function checkLinks() {
   }
 
   console.log('📂 Build directory:', buildDir);
+
+  // Auto-add versioned doc paths to ignorePatterns so version-switcher 404s
+  // for new pages don't surface as broken links. This picks up any future
+  // versions automatically without needing to update the config file.
+  const versionedPaths = detectVersionedPaths(buildDir);
+  if (versionedPaths.length > 0) {
+    config.ignorePatterns = [...(config.ignorePatterns || []), ...versionedPaths];
+    console.log(`📦 Auto-ignoring versioned paths: ${versionedPaths.join(', ')}\n`);
+  }
 
   try {
     // Start local server
@@ -648,8 +676,9 @@ async function checkLinks() {
         }
         allLinks.get(normalizedUrl).sourcePages.add(currentPath);
 
-        // Add to crawl queue if not visited
-        if (!visited.has(normalizedUrl) && !toVisit.includes(normalizedUrl)) {
+        // Add to crawl queue if not visited and not ignored
+        const isIgnored = config.ignorePatterns.some(pattern => normalizedUrl.includes(pattern));
+        if (!isIgnored && !visited.has(normalizedUrl) && !toVisit.includes(normalizedUrl)) {
           toVisit.push(normalizedUrl);
         }
       }


### PR DESCRIPTION
Syncs detailed guide content from the upstream `llm-d/llm-d` repo into the website. Each guide now has full content with working internal links and locally-hosted images. Also fixes the link checker so version-switcher 404s for new pages don't block CI.

Fixes https://github.com/llm-d/llm-d.github.io/issues/253

## What changed

**Guide content** — `sync-docs.sh` now copies every `README.md` from `guides/` (excluding `prereq/` and `experimental/`) as `index.md`, preserving directory structure. Images and benchmark assets are copied alongside the docs. Previously only well-lit-path overview stubs were synced.

**Sidebar** — `sidebars.ts` updated to match the new directory structure, with nested categories for guides that have sub-pages (Tiered Prefix Cache, Async Processing, Wide Expert Parallelism, Recipes).

**MDX compatibility** — `transformations.sh` gains three new passes run on all synced files:
- HTML comments (`<!-- -->`) converted to MDX comments (`{/* */}`)
- Placeholder-style angle brackets (e.g. `<your_gateway_choice>`) escaped
- `<=` / `>=` in prose escaped to avoid JSX parse errors

**Link fixes** — stale link names (`predicted-latency` → `predicted-latency-based-scheduling`, `wide-expert-parallelism` → `wide-ep-lws`, `pd-disaggregation` → correct `/docs/` prefix) are rewritten during sync. Prereq and helper file links that don't exist on the site are redirected to their upstream GitHub locations.

**Link checker** — `check-links.mjs` now auto-detects versioned snapshot directories (e.g. `build/docs/0.7.0/`) at startup and skips crawling them. The Docusaurus version-switcher generates links to older-version equivalents of new pages; those will always 404 and are not real content bugs. Future versions are picked up automatically without any config change.

## Preview links

| Page | URL |
|------|-----|
| Guide index | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides |
| Tiered Prefix Cache – CPU | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides/tiered-prefix-cache/cpu |
| Tiered Prefix Cache – Storage offloading ⭐ | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides/tiered-prefix-cache/storage |
| Tiered Prefix Cache – Lustre backend (resolves #253) ⭐ | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides/tiered-prefix-cache/storage/manifests/backends/lustre |
| Tiered Prefix Cache – AWS backend | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides/tiered-prefix-cache/storage/manifests/backends/aws |
| Wide EP – Experimental DP-Aware (with images) ✨ | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides/wide-ep-lws/experimental-dp-aware |
| Wide EP – Benchmarks | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides/wide-ep-lws/experimental-dp-aware/benchmarks |
| Async Processing – Redis | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides/asynchronous-processing/redis |
| Async Processing – GCP Pub/Sub | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides/asynchronous-processing/gcp-pubsub |
| Recipe – Gateway | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides/recipes/gateway |
| Recipe – Scheduler | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides/recipes/scheduler |
| Recipe – Disable GKE NCCL tuner patch | https://deploy-preview-292--elaborate-kangaroo-25e1ee.netlify.app/docs/guides/recipes/modelserver/components/disable-gke-nccl-tuner-patch |

## How was this tested?

- [x] `npm test` passes (transformation tests updated to match new MDX comment format)
- [x] `npm run build` succeeds
- [x] `npm run check-links` reports 0 broken links
- [x] Manual review of preview pages above

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build`)
- [x] Documentation updated (if applicable)