### PR TITLE
Fix: Force-add ignored docs in release branch workflows

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Commit synced docs
         run: |
-          git add preview/docs preview/static/img/docs
+          git add -f preview/docs preview/static/img/docs
           if ! git diff --staged --quiet; then
             git commit -m "Initial docs sync from llm-d/llm-d@${{ inputs.source_branch }}"
           else

--- a/.github/workflows/sync-release-docs.yml
+++ b/.github/workflows/sync-release-docs.yml
@@ -81,7 +81,7 @@ jobs:
             cd ..
 
             # Commit changes if any
-            git add preview/docs preview/static/img/docs
+            git add -f preview/docs preview/static/img/docs
             if ! git diff --staged --quiet; then
               COMMIT_MSG="Nightly docs sync from llm-d/llm-d@${SOURCE_BRANCH}
 


### PR DESCRIPTION
This PR fixes the workflow failure when creating release branches.

## Problem

When triggering `create-release-branch.yml` workflow, it fails at the "Commit synced docs" step:

```
The following paths are ignored by one of your .gitignore files:
preview/docs
hint: Use -f if you really want to add them.
```

The `preview/docs` directory is in `.gitignore` because on the main branch, docs are synced from upstream and shouldn't be committed. However, on release branches, we **do** want to commit these docs so they're versioned with the release.

## Solution

Update both workflows to use `git add -f` to force-add ignored files:
- `.github/workflows/create-release-branch.yml`
- `.github/workflows/sync-release-docs.yml`

## Testing

After merge, re-trigger the workflow:
```bash
gh workflow run create-release-branch.yml \
  --repo llm-d/llm-d.github.io \
  --field version=0.7.0 \
  --field source_branch=release-0.7
```

This should successfully create the `release-0.7.0` branch with committed docs.

## Impact

This unblocks the version dropdown on the live site. Currently clicking version 0.7.0 leads to a 404 because the release branch doesn't exist yet.