### PR TITLE
Fix deploy workflow: force remove worktrees with node_modules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
 
             # Clean up worktree
             cd "../../llm-d.github.io"
-            git worktree remove "../release-${VERSION}"
+            git worktree remove --force "../release-${VERSION}"
 
             echo "✓ Built version $VERSION"
           done


### PR DESCRIPTION
## Problem

The deploy workflow fails when building release branches with this error:

```
fatal: '../release-0.7.0' contains modified or untracked files, use --force to delete it
```

## Root Cause

1. Workflow creates worktree for release branch
2. Runs `npm install` which creates `node_modules/`
3. Tries to remove worktree with `git worktree remove` 
4. Git refuses because worktree has untracked files (node_modules)

## Fix

Add `--force` flag to `git worktree remove` command (line 83).

## Testing

Tested manually by creating release-0.7.0 branch and triggering deploy workflow. Failed with the error above. This PR fixes that specific failure.