### PR TITLE
Improve broken link reporting in CI

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -40,6 +40,15 @@ jobs:
       - name: Check links
         run: npm run check-links
 
+      - name: Add broken links to job summary
+        if: always()
+        run: |
+          if [ -f broken-links-report.md ]; then
+            cat broken-links-report.md >> $GITHUB_STEP_SUMMARY
+          else
+            echo "✅ No broken links found" >> $GITHUB_STEP_SUMMARY
+          fi
+
       - name: Upload broken links report
         if: always()
         uses: actions/upload-artifact@v7
@@ -47,10 +56,3 @@ jobs:
           name: broken-links-report
           path: broken-links-report.md
           if-no-files-found: ignore
-
-      - name: Post broken links report to PR
-        if: always() && github.event_name == 'pull_request' && hashFiles('broken-links-report.md') != ''
-        uses: marocchino/sticky-pull-request-comment@v3.0.4
-        with:
-          header: broken-links-report
-          path: broken-links-report.md

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -38,7 +38,6 @@ jobs:
           cp -r preview/build/img/docs/* build/img/docs/
 
       - name: Check links
-        id: check-links
         run: npm run check-links
 
       - name: Add broken links to job summary

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -21,21 +21,9 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-      - name: Test build website
-        run: npm run build
 
-      - name: Sync preview docs from llm-d/llm-d
-        run: cd preview && bash scripts/sync-docs.sh main
-
-      - name: Install preview docs dependencies
-        run: cd preview && npm install
-      - name: Test build preview docs
-        run: cd preview && npm run build
-      - name: Merge preview into main build as /docs
-        run: |
-          cp -r preview/build build/docs
-          mkdir -p build/img/docs
-          cp -r preview/build/img/docs/* build/img/docs/
+      - name: Build everything (main site + docs + all release versions)
+        run: npm run build:all
 
       - name: Check links
         run: npm run check-links

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -46,8 +46,6 @@ jobs:
         run: |
           if [ -f broken-links-report.md ]; then
             cat broken-links-report.md >> "$GITHUB_STEP_SUMMARY"
-          elif [ "${{ steps.check-links.outcome }}" == "success" ]; then
-            echo "✅ No broken links found" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "⚠️ Link check failed - no report generated" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -38,15 +38,18 @@ jobs:
           cp -r preview/build/img/docs/* build/img/docs/
 
       - name: Check links
+        id: check-links
         run: npm run check-links
 
       - name: Add broken links to job summary
         if: always()
         run: |
           if [ -f broken-links-report.md ]; then
-            cat broken-links-report.md >> $GITHUB_STEP_SUMMARY
+            cat broken-links-report.md >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.check-links.outcome }}" == "success" ]; then
+            echo "✅ No broken links found" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "✅ No broken links found" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ Link check failed - no report generated" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload broken links report

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -176,7 +176,7 @@ cp_doc "$WIP/accelerators/README.md"                 "$DOCS_DIR/accelerators/ind
 # Fix accelerators links to infra-providers
 if [[ -f "$DOCS_DIR/accelerators/index.md" ]]; then
     sed_inplace \
-        -e 's|\.\./infra-providers/gke/README\.md|/docs/resources/infra-providers/gke|g' \
+        -e 's|\.\./infra-providers/gke/README\.md|/resources/infra-providers/gke|g' \
         "$DOCS_DIR/accelerators/index.md"
 fi
 
@@ -217,14 +217,14 @@ find "$DOCS_DIR/resources/infra-providers" -name "*.md" -print0 | while IFS= rea
     sed_inplace \
         -e 's|\./images/\([^)]*\)|/img/docs/\1|g' \
         -e 's|](images/\([^)]*\))|](/img/docs/\1)|g' \
-        -e 's|\.\./\.\./\.\./guides/optimized-baseline/README\.md|/docs/guides/optimized-baseline|g' \
-        -e 's|\.\./\.\./\.\./guides/precise-prefix-cache-aware/README\.md|/docs/guides/precise-prefix-cache-aware|g' \
-        -e 's|\.\./\.\./\.\./guides/pd-disaggregation/README\.md|/docs/guides/pd-disaggregation|g' \
+        -e 's|\.\./\.\./\.\./guides/optimized-baseline/README\.md|/guides/optimized-baseline|g' \
+        -e 's|\.\./\.\./\.\./guides/precise-prefix-cache-aware/README\.md|/guides/precise-prefix-cache-aware|g' \
+        -e 's|\.\./\.\./\.\./guides/pd-disaggregation/README\.md|/guides/pd-disaggregation|g' \
         -e 's|\.\./\.\./\.\./guides/wide-ep-lws/README\.md|https://github.com/llm-d/llm-d/tree/main/guides/wide-ep-lws|g' \
         -e 's|\.\./\.\./\.\./guides/tiered-prefix-cache/README\.md|https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache|g' \
-        -e 's|\.\./\.\./\.\./guides/index\.md|/docs/guides|g' \
-        -e 's|\.\./\.\./\.\./guides/)|/docs/guides)|g' \
-        -e 's|\.\./\.\./\.\./guides)|/docs/guides)|g' \
+        -e 's|\.\./\.\./\.\./guides/index\.md|/guides|g' \
+        -e 's|\.\./\.\./\.\./guides/)|/guides)|g' \
+        -e 's|\.\./\.\./\.\./guides)|/guides)|g' \
         -e 's|\.\./\.\./\.\./helpers/client-setup/README\.md|https://github.com/llm-d/llm-d/tree/main/helpers/client-setup|g' \
         "$file"
 done
@@ -250,11 +250,11 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|advanced/disaggregation\.md|advanced/disaggregation/index.md|g' \
         -e 's|advanced/autoscaling/autoscaling\.md|advanced/autoscaling/index.md|g' \
         -e 's|advanced/batch/README\.md|advanced/batch/index.md|g' \
-        -e 's|\](/docs/guides/README)|\](/docs/guides)|g' \
-        -e 's|\](/docs/experimental/batch-gateway)|\](/docs/guides/experimental/batch-gateway)|g' \
-        -e 's|\](/docs/architecture/core/epp)|\](/docs/architecture/core/router/epp)|g' \
-        -e 's|\](/docs/well-lit-paths/\([^)]*\)\.md)|\](/docs/guides/\1)|g' \
-        -e 's|\](well-lit-paths/\([^)]*\))|\](/docs/guides/\1)|g' \
+        -e 's|\](/guides/README)|\](/guides)|g' \
+        -e 's|\](/experimental/batch-gateway)|\](/guides/experimental/batch-gateway)|g' \
+        -e 's|\](/architecture/core/epp)|\](/architecture/core/router/epp)|g' \
+        -e 's|\](/well-lit-paths/\([^)]*\)\.md)|\](/guides/\1)|g' \
+        -e 's|\](well-lit-paths/\([^)]*\))|\](/guides/\1)|g' \
         -e 's|\](.*\/guides/tiered-prefix-cache)|\](https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache)|g' \
         -e 's|\](.*\/guides/batch-gateway)|\](https://github.com/llm-d/llm-d/tree/main/guides/batch-gateway)|g' \
         -e 's|\](.*\/guides/asynchronous-processing)|\](https://github.com/llm-d/llm-d/tree/main/guides/asynchronous-processing)|g' \
@@ -270,11 +270,11 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](/guides/asynchronous-processing)|\](https://github.com/llm-d/llm-d/tree/main/guides/asynchronous-processing)|g' \
         -e 's|\](/guides/optimized-baseline)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline)|g' \
         -e 's|\](/guides/precise-prefix-cache-aware)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-aware)|g' \
-        -e 's|\](.*\/docs/infra-providers)|\](/docs/resources/infra-providers)|g' \
-        -e 's|\](.*\/infra-providers)|\](/docs/resources/infra-providers)|g' \
-        -e 's|\](/docs/infra-providers)|\](/docs/resources/infra-providers)|g' \
-        -e 's|\](infra-providers/\([^)]*\))|\](/docs/resources/infra-providers/\1)|g' \
-        -e 's|\](/docs/\([^)]*\)/README\.md)|\](/docs/\1)|g' \
+        -e 's|\](.*\/docs/infra-providers)|\](/resources/infra-providers)|g' \
+        -e 's|\](.*\/infra-providers)|\](/resources/infra-providers)|g' \
+        -e 's|\](/infra-providers)|\](/resources/infra-providers)|g' \
+        -e 's|\](infra-providers/\([^)]*\))|\](/resources/infra-providers/\1)|g' \
+        -e 's|\](/\([^)]*\)/README\.md)|\](/\1)|g' \
         "$file"
 done
 
@@ -282,11 +282,11 @@ done
 # gateway/index.md comes from guides/prereq/gateways/README.md — fix relative paths
 if [[ -f "$DOCS_DIR/resources/gateway/index.md" ]]; then
     sed_inplace \
-        -e 's|\](../../guides/README\.md)|\](/docs/guides)|g' \
-        -e 's|\](../../guides/index\.md)|\](/docs/guides)|g' \
-        -e 's|\](./gke\.md)|\](/docs/resources/gateway/gke)|g' \
-        -e 's|\](./istio\.md)|\](/docs/resources/gateway/istio)|g' \
-        -e 's|\](./agentgateway\.md)|\](/docs/resources/gateway/agentgateway)|g' \
+        -e 's|\](../../guides/README\.md)|\](/guides)|g' \
+        -e 's|\](../../guides/index\.md)|\](/guides)|g' \
+        -e 's|\](./gke\.md)|\](/resources/gateway/gke)|g' \
+        -e 's|\](./istio\.md)|\](/resources/gateway/istio)|g' \
+        -e 's|\](./agentgateway\.md)|\](/resources/gateway/agentgateway)|g' \
         "$DOCS_DIR/resources/gateway/index.md"
 fi
 
@@ -294,9 +294,9 @@ fi
 # rdma/rdma-configuration.md comes from resources-new/rdma/README.md
 if [[ -f "$DOCS_DIR/resources/rdma/rdma-configuration.md" ]]; then
     sed_inplace \
-        -e 's|\](../../well-lit-paths/pd-disaggregation\.md)|\](/docs/guides/pd-disaggregation)|g' \
-        -e 's|\](../../well-lit-paths/wide-expert-parallelism\.md)|\](/docs/guides/wide-expert-parallelism)|g' \
-        -e 's|\](../../architecture/core/model-servers\.md)|\](/docs/architecture/core/model-servers)|g' \
+        -e 's|\](../../well-lit-paths/pd-disaggregation\.md)|\](/guides/pd-disaggregation)|g' \
+        -e 's|\](../../well-lit-paths/wide-expert-parallelism\.md)|\](/guides/wide-expert-parallelism)|g' \
+        -e 's|\](../../architecture/core/model-servers\.md)|\](/architecture/core/model-servers)|g' \
         "$DOCS_DIR/resources/rdma/rdma-configuration.md"
 fi
 
@@ -305,7 +305,7 @@ fi
 if [[ -f "$DOCS_DIR/resources/monitoring/metrics.md" ]]; then
     sed_inplace \
         -e 's|\](../../../guides/recipes/modelserver/components/monitoring/)|\](https://github.com/llm-d/llm-d/tree/main/guides/recipes/modelserver/components/monitoring)|g' \
-        -e 's|\](../../getting-started/quickstart\.md)|\](/docs/getting-started/quickstart)|g' \
+        -e 's|\](../../getting-started/quickstart\.md)|\](/getting-started/quickstart)|g' \
         "$DOCS_DIR/resources/monitoring/metrics.md"
 fi
 
@@ -314,12 +314,12 @@ fi
 # Convert them to Docusaurus-compatible paths
 echo "    Fixing API reference links..."
 sed_inplace \
-    -e 's|\](inferencepool\.md)|\](/docs/api-reference/inferencepool)|g' \
-    -e 's|\](inferenceobjective\.md)|\](/docs/api-reference/inferenceobjective)|g' \
-    -e 's|\](inferencemodelrewrite\.md)|\](/docs/api-reference/inferencemodelrewrite)|g' \
-    -e 's|\](endpointpickerconfig\.md)|\](/docs/api-reference/endpointpickerconfig)|g' \
-    -e 's|\](epp-http-headers\.md)|\](/docs/api-reference/epp-http-headers)|g' \
-    -e 's|\](glossary\.md)|\](/docs/api-reference/glossary)|g' \
+    -e 's|\](inferencepool\.md)|\](/api-reference/inferencepool)|g' \
+    -e 's|\](inferenceobjective\.md)|\](/api-reference/inferenceobjective)|g' \
+    -e 's|\](inferencemodelrewrite\.md)|\](/api-reference/inferencemodelrewrite)|g' \
+    -e 's|\](endpointpickerconfig\.md)|\](/api-reference/endpointpickerconfig)|g' \
+    -e 's|\](epp-http-headers\.md)|\](/api-reference/epp-http-headers)|g' \
+    -e 's|\](glossary\.md)|\](/api-reference/glossary)|g' \
     "$DOCS_DIR/api-reference/index.md"
 
 # === Fix architecture index.md relative paths ===
@@ -327,31 +327,31 @@ sed_inplace \
 # Convert ./core/* and ./advanced/* to absolute paths with /architecture/ prefix
 echo "    Fixing architecture index.md relative paths..."
 sed_inplace \
-    -e 's|\(\[.*\]\)(\./core/inferencepool)|\1(/docs/architecture/core/inferencepool)|g' \
-    -e 's|\(\[.*\]\)(\./core/model-servers)|\1(/docs/architecture/core/model-servers)|g' \
-    -e 's|\(\[.*\]\)(\./core/router/proxy)|\1(/docs/architecture/core/router/proxy)|g' \
-    -e 's|\(\[.*\]\)(\./core/router/)|\1(/docs/architecture/core/router)|g' \
-    -e 's|\(\[.*\]\)(\./core/router)|\1(/docs/architecture/core/router)|g' \
-    -e 's|\(\[.*\]\)(\./core/router/epp/)|\1(/docs/architecture/core/router/epp)|g' \
-    -e 's|\(\[.*\]\)(\./advanced/kv-management/)|\1(/docs/architecture/advanced/kv-management)|g' \
-    -e 's|\(\[.*\]\)(\./advanced/kv-management)|\1(/docs/architecture/advanced/kv-management)|g' \
-    -e 's|\](core/router/README\.md)|\](/docs/architecture/core/router)|g' \
-    -e 's|\](core/router/epp/README\.md)|\](/docs/architecture/core/router/epp)|g' \
-    -e 's|\](core/inferencepool\.md)|\](/docs/architecture/core/inferencepool)|g' \
-    -e 's|\](core/model-servers\.md)|\](/docs/architecture/core/model-servers)|g' \
-    -e 's|\](advanced/kv-management/README\.md)|\](/docs/architecture/advanced/kv-management)|g' \
-    -e 's|\](/docs/core/router/README\.md)|\](/docs/architecture/core/router)|g' \
-    -e 's|\](/docs/core/router/epp/README\.md)|\](/docs/architecture/core/router/epp)|g' \
-    -e 's|\](/docs/advanced/kv-management/README\.md)|\](/docs/architecture/advanced/kv-management)|g' \
+    -e 's|\(\[.*\]\)(\./core/inferencepool)|\1(/architecture/core/inferencepool)|g' \
+    -e 's|\(\[.*\]\)(\./core/model-servers)|\1(/architecture/core/model-servers)|g' \
+    -e 's|\(\[.*\]\)(\./core/router/proxy)|\1(/architecture/core/router/proxy)|g' \
+    -e 's|\(\[.*\]\)(\./core/router/)|\1(/architecture/core/router)|g' \
+    -e 's|\(\[.*\]\)(\./core/router)|\1(/architecture/core/router)|g' \
+    -e 's|\(\[.*\]\)(\./core/router/epp/)|\1(/architecture/core/router/epp)|g' \
+    -e 's|\(\[.*\]\)(\./advanced/kv-management/)|\1(/architecture/advanced/kv-management)|g' \
+    -e 's|\(\[.*\]\)(\./advanced/kv-management)|\1(/architecture/advanced/kv-management)|g' \
+    -e 's|\](core/router/README\.md)|\](/architecture/core/router)|g' \
+    -e 's|\](core/router/epp/README\.md)|\](/architecture/core/router/epp)|g' \
+    -e 's|\](core/inferencepool\.md)|\](/architecture/core/inferencepool)|g' \
+    -e 's|\](core/model-servers\.md)|\](/architecture/core/model-servers)|g' \
+    -e 's|\](advanced/kv-management/README\.md)|\](/architecture/advanced/kv-management)|g' \
+    -e 's|\](/core/router/README\.md)|\](/architecture/core/router)|g' \
+    -e 's|\](/core/router/epp/README\.md)|\](/architecture/core/router/epp)|g' \
+    -e 's|\](/advanced/kv-management/README\.md)|\](/architecture/advanced/kv-management)|g' \
     "$DOCS_DIR/architecture/index.md"
 
 # === Fix router index.md relative paths ===
 # Similar issue with router/index.md
 sed_inplace \
-    -e 's|\](\.\/epp/)|\](/docs/architecture/core/router/epp)|g' \
-    -e 's|\](\.\/epp)|\](/docs/architecture/core/router/epp)|g' \
-    -e 's|\](epp/README\.md)|\](/docs/architecture/core/router/epp)|g' \
-    -e 's|\](/docs/architecture/core/epp/README\.md)|\](/docs/architecture/core/router/epp)|g' \
+    -e 's|\](\.\/epp/)|\](/architecture/core/router/epp)|g' \
+    -e 's|\](\.\/epp)|\](/architecture/core/router/epp)|g' \
+    -e 's|\](epp/README\.md)|\](/architecture/core/router/epp)|g' \
+    -e 's|\](/architecture/core/epp/README\.md)|\](/architecture/core/router/epp)|g' \
     "$DOCS_DIR/architecture/core/router/index.md"
 
 # === Clean up known issues ===

--- a/preview/scripts/test-fixtures/transformation-test.expected.md
+++ b/preview/scripts/test-fixtures/transformation-test.expected.md
@@ -212,26 +212,26 @@ Content with @ symbol.
 Test that well-lit-paths links are transformed correctly:
 
 Single level up:
-[Optimized Baseline](/docs/guides/optimized-baseline)
+[Optimized Baseline](/guides/optimized-baseline)
 
 Two levels up:
-[PD Disaggregation](/docs/guides/pd-disaggregation)
+[PD Disaggregation](/guides/pd-disaggregation)
 
 Index/README:
-[All Guides](/docs/guides)
+[All Guides](/guides)
 
 With any number of parent directories:
-[Guide Link](/docs/guides/flow-control)
+[Guide Link](/guides/flow-control)
 
 ## 11. README.md Link Transformations
 
 Test that README links are transformed correctly:
 
 Link to accelerators README:
-[Accelerators](/docs/accelerators)
+[Accelerators](/accelerators)
 
 Link to architecture router epp README:
-[EPP](/docs/architecture/core/router/epp)
+[EPP](/architecture/core/router/epp)
 
 Link to KV management README:
-[KV Management](/docs/architecture/advanced/kv-management)
+[KV Management](/architecture/advanced/kv-management)

--- a/preview/scripts/transformations.sh
+++ b/preview/scripts/transformations.sh
@@ -51,29 +51,29 @@ apply_transformations() {
     sed_inplace '/^|.*|$/ s|{|(|g' "$file"
     sed_inplace '/^|.*|$/ s|}|)|g' "$file"
 
-    # Fix well-lit-paths links (convert to /docs/guides for Docusaurus)
+    # Fix well-lit-paths links (convert to /guides for Docusaurus)
     # Source files use ../well-lit-paths/*.md for GitHub compatibility
-    # Convert to /docs/guides/* for Docusaurus
+    # Convert to /guides/* for Docusaurus (baseUrl will be prepended)
     sed_inplace \
-        -E 's|\(\.\./well-lit-paths/([^)]+)\.md\)|(/docs/guides/\1)|g' \
+        -E 's|\(\.\./well-lit-paths/([^)]+)\.md\)|(/guides/\1)|g' \
         "$file"
 
     # Also handle paths with multiple ../ and any path to well-lit-paths
     sed_inplace \
-        -e 's|\](.*\/well-lit-paths/\([^)]*\)\.md)|\](/docs/guides/\1)|g' \
+        -e 's|\](.*\/well-lit-paths/\([^)]*\)\.md)|\](/guides/\1)|g' \
         "$file"
 
     # Fix README.md links to index pages
-    # Convert paths like ../architecture/core/router/epp/README.md to /docs/architecture/core/router/epp
+    # Convert paths like ../architecture/core/router/epp/README.md to /architecture/core/router/epp
     sed_inplace \
-        -e 's|\](.*\/accelerators/README\.md)|\](/docs/accelerators)|g' \
-        -e 's|\](.*\/architecture/core/router/epp/README\.md)|\](/docs/architecture/core/router/epp)|g' \
-        -e 's|\](.*\/architecture/advanced/kv-management/README\.md)|\](/docs/architecture/advanced/kv-management)|g' \
+        -e 's|\](.*\/accelerators/README\.md)|\](/accelerators)|g' \
+        -e 's|\](.*\/architecture/core/router/epp/README\.md)|\](/architecture/core/router/epp)|g' \
+        -e 's|\](.*\/architecture/advanced/kv-management/README\.md)|\](/architecture/advanced/kv-management)|g' \
         "$file"
 
-    # Fix /docs/guides/README (without .md extension)
+    # Fix /guides/README (without .md extension)
     sed_inplace \
-        -e 's|\](/docs/guides/README)|\](/docs/guides)|g' \
+        -e 's|\](/guides/README)|\](/guides)|g' \
         "$file"
 
     # Fix deployment guide links to GitHub URLs

--- a/preview/src/pages/index.tsx
+++ b/preview/src/pages/index.tsx
@@ -21,12 +21,12 @@ function HeroSection() {
         <div className={styles.buttons}>
           <Link
             className="button button--primary button--lg"
-            to="/docs/getting-started">
+            to="/getting-started">
             Get Started
           </Link>
           <Link
             className="button button--outline button--lg"
-            to="/docs/getting-started/quickstart"
+            to="/getting-started/quickstart"
             style={{marginLeft: '0.75rem'}}>
             Quickstart
           </Link>
@@ -39,27 +39,27 @@ function HeroSection() {
 const sections = [
   {
     title: 'Getting Started',
-    to: '/docs/getting-started',
+    to: '/getting-started',
     description: 'Introduction to llm-d, quickstart guide, feature matrix, and release artifacts.',
   },
   {
     title: 'Architecture',
-    to: '/docs/architecture',
+    to: '/architecture',
     description: 'Core components — Proxy, InferencePool, EPP, Model Servers — and advanced features.',
   },
   {
     title: 'Guides',
-    to: '/docs/guides',
+    to: '/guides',
     description: 'Step-by-step adoption procedures: scheduling, disaggregation, expert parallelism, caching.',
   },
   {
     title: 'Resources',
-    to: '/docs/resources/gateway',
+    to: '/resources/gateway',
     description: 'Gateway setup, API configuration, monitoring, multi-model deployment, and RDMA.',
   },
   {
     title: 'API Reference',
-    to: '/docs/api-reference',
+    to: '/api-reference',
     description: 'API specifications and reference documentation.',
   },
 ];

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -763,7 +763,10 @@ async function checkLinks() {
     console.log(`   Broken links found: ${brokenLinks.length}`);
 
     if (brokenLinks.length > 0) {
-      console.log(`\n⚠️  Found ${brokenLinks.length} broken links. See report for details.`);
+      console.log(`\n⚠️  Found ${brokenLinks.length} broken links:\n`);
+      console.log('─'.repeat(80));
+      console.log(report);
+      console.log('─'.repeat(80));
       await stopServer();
       process.exit(1); // Exit with error code to fail CI
     } else {


### PR DESCRIPTION
## What does this PR do?

Swap out the sticky PR comment for broken link reports in favor of GitHub Actions job summary. It shows up right in the workflow run instead of cluttering the PR and also should not require write access to run the build. Also prints broken links inline in the CI logs so you don't have to download an artifact to see what failed.


