### PR TITLE
Enhances error logging for process cleanup

### DIFF
--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -112,6 +112,7 @@ async function stopServer() {
         try {
           await killProcessOnPort(config.serverPort);
         } catch (e) {
+          console.error('Error killing process on port:', e.message);
           // Ignore errors
         }
 
@@ -120,10 +121,12 @@ async function stopServer() {
           try {
             process.kill(-serverProcess.pid, 'SIGKILL');
           } catch (e) {
+            console.error('Error killing process group:', e.message);
             // Fallback to killing just the main process
             try {
               serverProcess.kill('SIGKILL');
             } catch (e2) {
+              console.error('Error killing main process:', e2.message);
               // Process already dead
             }
           }
@@ -143,10 +146,12 @@ async function stopServer() {
         // Negative PID kills the process group
         process.kill(-serverProcess.pid, 'SIGTERM');
       } catch (e) {
+        console.error('Error killing process group:', e.message);
         // Fallback to killing just the main process if process group fails
         try {
           serverProcess.kill('SIGTERM');
         } catch (e2) {
+          console.error('Error killing main process:', e2.message);
           // Process might already be dead, that's fine
           clearTimeout(timeout);
           serverProcess = null;
@@ -173,6 +178,7 @@ async function killProcessOnPort(port) {
         try {
           process.kill(parseInt(pid), 'SIGKILL');
         } catch (e) {
+          console.error('Error killing process:', e.message);
           // Process might already be dead
         }
         resolve();

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -109,12 +109,7 @@ async function stopServer() {
       // Set a shorter timeout to force kill if it doesn't stop gracefully
       const timeout = setTimeout(async () => {
         // Try to find and kill process by port as last resort
-        try {
-          await killProcessOnPort(config.serverPort);
-        } catch (e) {
-          console.error('Error killing process on port:', e.message);
-          // Ignore errors
-        }
+        await killProcessOnPort(config.serverPort);
 
         if (serverProcess && !serverProcess.killed) {
           // Kill the entire process group to ensure all child processes are terminated


### PR DESCRIPTION
## What does this PR do?

Adds more specific error logging to `stopServer` and `killProcessOnPort` functions within the link checking script. When attempts to kill processes or process groups fail, the `e.message` is now logged to the console, providing more context about the error.

## Why is this change needed?

This change improves the debuggability of the link checking script. By logging detailed error messages when process termination fails, it becomes easier to identify and troubleshoot issues related to orphaned processes or server shutdown failures during the cleanup phase.

## How was this tested?

- [ ] Tests added/updated (`npm test`)
- [ ] Site builds successfully (`npm run build`)
- [x] Manual testing performed (`npm start`)

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [ ] Tests pass locally (`npm test`)
- [ ] Site builds without errors (`npm run build`)
- [ ] Documentation updated (if applicable)

## Related Issues