### PR TITLE
fix(docs): logo links back to llm-d.ai landing page

### DIFF
--- a/preview/docusaurus.config.ts
+++ b/preview/docusaurus.config.ts
@@ -100,6 +100,8 @@ const config: Config = {
       logo: {
         alt: 'llm-d',
         src: 'img/llm-d-logo-navbar.png',
+        href: 'https://llm-d.ai',
+        target: '_self',
       },
       items: [
         {


### PR DESCRIPTION

## What does this PR do?

Previously the logo on /docs/ pages linked to /docs/ (the docs root), leaving no way to navigate back to the main llm-d.ai landing page from within the docs site. Set the navbar logo href to https://llm-d.ai with target=_self so it returns to the landing page in the same tab.

## Why is this change needed?

Fix detailed in #300 

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build`)
- [ ] Manual testing performed (`npm start`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build`)
- [ ] Documentation updated (if applicable)

## Related Issues

#300 
