### PR TITLE
fix(docs): serve latest release at /docs/, move dev to /docs/dev/

### DIFF
--- a/blog/2025-09-24_kvcache-wins-you-can-see.md
+++ b/blog/2025-09-24_kvcache-wins-you-can-see.md
@@ -18,7 +18,7 @@ tags: [blog, updates, llm-d]
 
 The llm-d project provides a series of “well-lit paths” \- tested, benchmarked solutions for deploying large language models in production. Our first path, [**Intelligent Inference Scheduling**](/blog/intelligent-inference-scheduling-with-llm-d), established a baseline for AI-aware routing by balancing both cluster load and prefix-cache affinities. The default configuration for that path uses an *approximate* method for the latter, predicting cache locality based on request traffic.
 
-This blog illuminates a more advanced and powerful path: [**precise prefix-cache aware scheduling**](/docs/guides/precise-prefix-cache-routing).
+This blog illuminates a more advanced and powerful path: [**precise prefix-cache aware scheduling**](/docs/guides/precise-prefix-cache-aware).
 
 We take a deep dive into the next generation of this feature, which moves beyond prediction and gives the scheduler direct introspection into distributed vLLM caches. This precision is key to maximizing cache hit rates and achieving a new level of performance and maximizing cost-efficiency in your distributed deployments.
 

--- a/preview/RELEASE-BRANCH-SYNC.md
+++ b/preview/RELEASE-BRANCH-SYNC.md
@@ -82,12 +82,14 @@ Before any release branches exist, dev docs are served at `/docs/` (no
 
 The version dropdown component (`preview/src/components/VersionDropdown.tsx`) intelligently routes users:
 
-- **Latest stable**: Links to the canonical `/docs/{page}` URL (no version segment)
-- **Dev (main)**: Links to `/docs/dev/{page}`
-- **Other versions >= 0.7.0**: Link to `/docs/{version}/{page}` on the website
+- **Latest stable**: Links to the canonical `/docs/` URL (no version segment)
+- **Dev (main)**: Links to `/docs/dev/`
+- **Other versions >= 0.7.0**: Link to `/docs/{version}/` on the website
 - **Version < 0.7.0**: Links to GitHub tree view (legacy releases)
-- **Page path preservation**: Maintains current page when switching versions
-  - Example: On `/docs/dev/architecture` → Click latest (v0.7.0) → Go to `/docs/architecture`
+- **Version switches always land on the target version's home page** rather
+  than preserving the current page path, because dev typically has pages
+  that don't yet exist in the latest release (and vice versa for renamed
+  pages), and a path-preserving link would 404 in those cases.
 
 ## Creating a New Release
 

--- a/preview/RELEASE-BRANCH-SYNC.md
+++ b/preview/RELEASE-BRANCH-SYNC.md
@@ -10,10 +10,12 @@ Starting with release 0.7.0, documentation for each release is maintained on ded
 
 ### Branch Structure
 
-- **Main branch**: Always shows latest development docs (from llm-d/llm-d@main)
+- **Main branch**: Backs the development docs (from llm-d/llm-d@main)
+  - Deployed to `/docs/dev/` on the website
 - **Release branches**: Named `release-X.Y.Z` (e.g., `release-0.7.0`)
-  - Syncs nightly from `llm-d/llm-d@release-X.Y` 
+  - Syncs nightly from `llm-d/llm-d@release-X.Y`
   - Deployed to `/docs/X.Y.Z/` on the website
+  - The highest version is additionally served at the canonical `/docs/` URL
 
 ### Workflows
 
@@ -60,23 +62,32 @@ gh workflow run create-release-branch.yml \
 
 **What it does**:
 1. Builds main website
-2. Builds preview docs (dev/main)
-3. Discovers and builds all release branches
-4. Merges everything into a single artifact:
+2. Discovers all release branches and identifies the highest version
+3. Builds dev docs (from llm-d/llm-d@main) to `/docs/dev/`
+4. Builds each release branch to `/docs/{version}/`; the highest version is
+   additionally built with `DOCS_BASE_URL=/docs/` and served at the canonical
+   `/docs/` URL
+5. Merges everything into a single artifact:
    - `/` → Main website
-   - `/docs/` → Preview docs (dev)
+   - `/docs/` → Latest stable docs (mirrors the highest `/docs/X.Y.Z/`)
+   - `/docs/dev/` → Development docs (from `llm-d/llm-d@main`)
    - `/docs/0.7.0/` → Release 0.7.0 docs
    - `/docs/0.8.0/` → Release 0.8.0 docs
    - etc.
+
+Before any release branches exist, dev docs are served at `/docs/` (no
+`/docs/dev/` is produced) so the site remains usable pre-launch.
 
 ### Version Picker
 
 The version dropdown component (`preview/src/components/VersionDropdown.tsx`) intelligently routes users:
 
-- **Version >= 0.7.0**: Links to `/docs/{version}/` on the website
+- **Latest stable**: Links to the canonical `/docs/{page}` URL (no version segment)
+- **Dev (main)**: Links to `/docs/dev/{page}`
+- **Other versions >= 0.7.0**: Link to `/docs/{version}/{page}` on the website
 - **Version < 0.7.0**: Links to GitHub tree view (legacy releases)
 - **Page path preservation**: Maintains current page when switching versions
-  - Example: On `/docs/architecture` → Click v0.7.0 → Go to `/docs/0.7.0/architecture`
+  - Example: On `/docs/dev/architecture` → Click latest (v0.7.0) → Go to `/docs/architecture`
 
 ## Creating a New Release
 
@@ -122,17 +133,18 @@ Deployment happens automatically on the next push to main or via the nightly bui
 After creating release 0.7.0:
 
 - `https://llm-d.ai/` → Main website
-- `https://llm-d.ai/docs/` → Dev docs (main branch)
-- `https://llm-d.ai/docs/0.7.0/` → Release 0.7.0 docs
+- `https://llm-d.ai/docs/` → Latest stable docs (currently 0.7.0)
+- `https://llm-d.ai/docs/dev/` → Dev docs (main branch)
+- `https://llm-d.ai/docs/0.7.0/` → Release 0.7.0 docs (stable deep-link)
 - `https://llm-d.ai/docs/0.7.0/getting-started/` → Specific page in 0.7.0
 
 ## Version Mapping
 
 | Release Branch (llm-d.github.io) | Source Branch (llm-d/llm-d) | Website Path |
 |----------------------------------|----------------------------|--------------|
-| `release-0.7.0` | `release-0.7` | `/docs/0.7.0/` |
-| `release-0.8.0` | `release-0.8` | `/docs/0.8.0/` |
-| `main` | `main` | `/docs/` (dev) |
+| highest `release-X.Y.Z`          | `release-X.Y`              | `/docs/` *and* `/docs/X.Y.Z/` |
+| other `release-X.Y.Z`            | `release-X.Y`              | `/docs/X.Y.Z/` |
+| `main`                           | `main`                     | `/docs/dev/` |
 
 ## Maintenance
 

--- a/preview/VERSIONING.md
+++ b/preview/VERSIONING.md
@@ -57,9 +57,14 @@ git push
 ```
 
 ## URL Structure After 0.7 Release
-- `/docs/` → 0.7 (latest stable)
-- `/docs/next/` → dev (main branch)
-- `/docs/0.6/` → 0.6 (when created)
+- `/docs/` → latest stable (e.g. 0.7) — canonical URL
+- `/docs/dev/` → dev (main branch)
+- `/docs/0.7.0/` → 0.7.0 (stable deep-link, mirrors `/docs/`)
+- `/docs/0.6.0/` → 0.6.0 (when created)
+
+> The active implementation uses release branches and a custom version
+> dropdown rather than Docusaurus's built-in versioning. See
+> [RELEASE-BRANCH-SYNC.md](./RELEASE-BRANCH-SYNC.md) for the canonical flow.
 
 ## Creating Additional Versions
 To add 0.6, 0.5, etc.:

--- a/preview/docusaurus.config.ts
+++ b/preview/docusaurus.config.ts
@@ -84,8 +84,11 @@ const config: Config = {
             return `https://github.com/llm-d/llm-d/blob/main/docs/${sourcePath}`;
           },
           showLastUpdateTime: true,
-          // No Docusaurus versioning - dev (main) is always at /docs/
-          // Stable releases link to GitHub via custom version dropdown
+          // No Docusaurus versioning. Versioning is handled at the build layer
+          // (scripts/build-all.sh): the latest stable release is served at the
+          // canonical /docs/ URL, dev lives at /docs/dev/, and each release-X.Y.Z
+          // branch is also exposed at /docs/X.Y.Z/. The navbar dropdown
+          // (preview/src/components/VersionDropdown.tsx) routes between them.
         },
         blog: false,
         theme: {

--- a/preview/src/components/VersionDropdown.tsx
+++ b/preview/src/components/VersionDropdown.tsx
@@ -4,6 +4,7 @@ import {useLocation} from '@docusaurus/router';
 
 const REPO_URL = 'https://github.com/llm-d/llm-d/tree';
 const MIN_WEBSITE_VERSION = '0.7.0';
+const DEV_VERSION = 'dev';
 
 // Compare semver versions (simple implementation for x.y.z format)
 function isVersionGTE(version: string, target: string): boolean {
@@ -29,9 +30,15 @@ export default function VersionDropdown(): React.JSX.Element {
   const location = useLocation();
   const [releases, setReleases] = React.useState<string[]>(pluginData?.releases || []);
 
+  // Use the browser URL when hydrated; during SSR useLocation() already
+  // returns the absolute pathname Docusaurus rendered the page at (e.g.
+  // "/docs/dev/architecture"), so no reconstruction is needed.
+  const getFullPath = (): string =>
+    typeof window !== 'undefined' ? window.location.pathname : location.pathname;
+
   // Fallback: if plugin data is missing, fetch releases.json directly.
-  // Always fetch from the root /docs/ build since both dev and versioned builds
-  // contain the same releases.json with the full list.
+  // Always fetch from the root /docs/ build since every versioned build
+  // ships the same releases.json with the full list.
   React.useEffect(() => {
     if (!pluginData?.releases || pluginData.releases.length === 0) {
       const base =
@@ -39,7 +46,6 @@ export default function VersionDropdown(): React.JSX.Element {
       fetch(`${base}/docs/releases.json`)
         .then(res => res.json())
         .then(data => {
-          // Validate that data is an array of strings
           if (Array.isArray(data) && data.every(v => typeof v === 'string')) {
             setReleases(data);
           } else {
@@ -50,8 +56,8 @@ export default function VersionDropdown(): React.JSX.Element {
     }
   }, [pluginData]);
 
-  // Latest stable version (first in releases list)
   const latestTag = releases?.[0];
+  const latestVersion = latestTag?.replace(/^v/, '');
   const olderReleases = releases?.slice(1) || [];
 
   // Detect current version from the actual browser URL (window.location.pathname).
@@ -59,74 +65,95 @@ export default function VersionDropdown(): React.JSX.Element {
   // the '/docs/' prefix, making it unreliable for detecting which versioned build
   // we're in. window.location.pathname always reflects the full URL as shown in
   // the browser, so '/docs/0.7.0/getting-started' → "0.7.0".
+  //
+  // Returns 'dev' for /docs/dev/*, the version string for /docs/X.Y.Z/*, or
+  // the latest version string for any other /docs/* (the canonical URL serves
+  // the latest stable release).
   const getCurrentVersion = (): string | null => {
-    const path =
-      typeof window !== 'undefined' ? window.location.pathname : location.pathname;
+    const path = getFullPath();
 
-    // Full URL: /docs/0.7.0/...
+    if (/^\/docs\/dev(\/|$)/.test(path)) return DEV_VERSION;
+
     let match = path.match(/^\/docs\/(\d+\.\d+(?:\.\d+)?)\//);
     if (match) return match[1];
 
-    // Relative path after baseUrl strip: /0.7.0/...
+    // Relative path after baseUrl strip
+    if (/^\/dev(\/|$)/.test(path)) return DEV_VERSION;
     match = path.match(/^\/(\d+\.\d+(?:\.\d+)?)\//);
-    return match ? match[1] : null;
+    if (match) return match[1];
+
+    // Bare /docs/... → canonical URL → latest stable
+    return latestVersion || null;
   };
 
   const currentVersion = getCurrentVersion();
 
-  // Extract current page path to preserve when switching versions
-  // e.g., /docs/architecture/core/proxy -> architecture/core/proxy
-  // e.g., /docs/0.7.0/architecture -> architecture (strip version)
+  // Extract current page path to preserve when switching versions.
   // Uses window.location.pathname for the same reason as getCurrentVersion():
   // useLocation() is baseUrl-relative and won't contain the /docs/ prefix when
   // the versioned build has baseUrl='/docs/0.7.0/', causing version-switch links
   // to always fall back to 'getting-started' instead of the current page.
   const getCurrentPagePath = () => {
-    const path =
-      typeof window !== 'undefined' ? window.location.pathname : location.pathname;
+    const path = getFullPath();
     const match = path.match(/^\/docs\/(.+)$/);
     if (!match) return 'getting-started';
 
     let pagePath = match[1];
 
-    // Strip version number if present (e.g., "0.7.0/architecture" -> "architecture")
-    // Version pattern: starts with digit(s).digit(s) optionally followed by .digit(s)
-    const versionMatch = pagePath.match(/^(\d+\.\d+(?:\.\d+)?)\/(.*)/);
-    if (versionMatch) {
-      pagePath = versionMatch[2];
+    if (pagePath === 'dev' || pagePath.startsWith('dev/')) {
+      pagePath = pagePath.replace(/^dev\/?/, '');
+    } else {
+      const versionMatch = pagePath.match(/^(\d+\.\d+(?:\.\d+)?)\/(.*)/);
+      if (versionMatch) {
+        pagePath = versionMatch[2];
+      }
     }
 
     return pagePath || 'getting-started';
   };
 
-  // Generate URL for a version
+  // Generate URL for a version. The latest stable lives at the canonical
+  // /docs/ URL; older 0.7.0+ versions live at /docs/{version}/; pre-0.7.0
+  // versions link out to GitHub.
   const getVersionUrl = (tag: string) => {
     const version = tag.replace(/^v/, '');
     const pagePath = getCurrentPagePath();
 
-    if (isVersionGTE(version, MIN_WEBSITE_VERSION)) {
-      // Version 0.7.0+ hosted on website
-      return `/docs/${version}/${pagePath}`;
-    } else {
-      // Pre-0.7.0 versions link to GitHub
-      return `${REPO_URL}/${tag}/docs`;
+    if (latestTag && tag === latestTag) {
+      return `/docs/${pagePath}`;
     }
+    if (isVersionGTE(version, MIN_WEBSITE_VERSION)) {
+      return `/docs/${version}/${pagePath}`;
+    }
+    return `${REPO_URL}/${tag}/docs`;
   };
 
-  // Check if link should open in new tab (GitHub links only)
+  // Dev docs live under /docs/dev/ once a stable release exists; before the
+  // first release they remain at /docs/ (matches build-all.sh fallback).
+  const getDevUrl = () => {
+    const pagePath = getCurrentPagePath();
+    return latestTag ? `/docs/dev/${pagePath}` : `/docs/${pagePath}`;
+  };
+
   const isExternalLink = (tag: string) => {
     const version = tag.replace(/^v/, '');
     return !isVersionGTE(version, MIN_WEBSITE_VERSION);
   };
 
-  // Get display label for dropdown button
   const getDropdownLabel = () => {
-    if (!currentVersion) return 'dev ▾';
+    if (currentVersion === DEV_VERSION || !currentVersion) return 'dev ▾';
 
     const vTag = `v${currentVersion}`;
     if (vTag === latestTag) return `${vTag} (latest) ▾`;
     return `${vTag} ▾`;
   };
+
+  const isDevActive = currentVersion === DEV_VERSION;
+  const isLatestActive =
+    !!latestTag &&
+    !!currentVersion &&
+    currentVersion !== DEV_VERSION &&
+    `v${currentVersion}` === latestTag;
 
   return (
     <div className="navbar__item dropdown dropdown--hoverable">
@@ -136,10 +163,10 @@ export default function VersionDropdown(): React.JSX.Element {
       <ul className="dropdown__menu">
         <li>
           <a
-            className={`dropdown__link ${!currentVersion ? 'dropdown__link--active' : ''}`}
-            href={`/docs/${getCurrentPagePath()}`}
+            className={`dropdown__link ${isDevActive ? 'dropdown__link--active' : ''}`}
+            href={getDevUrl()}
           >
-            dev (main)
+            dev
           </a>
         </li>
         {latestTag && (
@@ -150,7 +177,7 @@ export default function VersionDropdown(): React.JSX.Element {
             }} />
             <li>
               <a
-                className={`dropdown__link ${currentVersion && `v${currentVersion}` === latestTag ? 'dropdown__link--active' : ''}`}
+                className={`dropdown__link ${isLatestActive ? 'dropdown__link--active' : ''}`}
                 href={getVersionUrl(latestTag)}
                 {...(isExternalLink(latestTag) && {
                   target: '_blank',
@@ -167,7 +194,7 @@ export default function VersionDropdown(): React.JSX.Element {
             {olderReleases.map((tag) => (
               <li key={tag}>
                 <a
-                  className={`dropdown__link ${currentVersion && `v${currentVersion}` === tag ? 'dropdown__link--active' : ''}`}
+                  className={`dropdown__link ${currentVersion && currentVersion !== DEV_VERSION && `v${currentVersion}` === tag ? 'dropdown__link--active' : ''}`}
                   href={getVersionUrl(tag)}
                   {...(isExternalLink(tag) && {
                     target: '_blank',

--- a/preview/src/components/VersionDropdown.tsx
+++ b/preview/src/components/VersionDropdown.tsx
@@ -88,52 +88,26 @@ export default function VersionDropdown(): React.JSX.Element {
 
   const currentVersion = getCurrentVersion();
 
-  // Extract current page path to preserve when switching versions.
-  // Uses window.location.pathname for the same reason as getCurrentVersion():
-  // useLocation() is baseUrl-relative and won't contain the /docs/ prefix when
-  // the versioned build has baseUrl='/docs/0.7.0/', causing version-switch links
-  // to always fall back to 'getting-started' instead of the current page.
-  const getCurrentPagePath = () => {
-    const path = getFullPath();
-    const match = path.match(/^\/docs\/(.+)$/);
-    if (!match) return 'getting-started';
-
-    let pagePath = match[1];
-
-    if (pagePath === 'dev' || pagePath.startsWith('dev/')) {
-      pagePath = pagePath.replace(/^dev\/?/, '');
-    } else {
-      const versionMatch = pagePath.match(/^(\d+\.\d+(?:\.\d+)?)\/(.*)/);
-      if (versionMatch) {
-        pagePath = versionMatch[2];
-      }
-    }
-
-    return pagePath || 'getting-started';
-  };
-
-  // Generate URL for a version. The latest stable lives at the canonical
-  // /docs/ URL; older 0.7.0+ versions live at /docs/{version}/; pre-0.7.0
-  // versions link out to GitHub.
+  // Generate URL for a version. Each version's landing page is the target;
+  // we deliberately don't preserve the current page path because dev and
+  // older releases have different page sets, so a path-preserving link
+  // would 404 whenever the current page doesn't exist in the target
+  // version (e.g. on a dev page added after the last release).
   const getVersionUrl = (tag: string) => {
     const version = tag.replace(/^v/, '');
-    const pagePath = getCurrentPagePath();
 
     if (latestTag && tag === latestTag) {
-      return `/docs/${pagePath}`;
+      return '/docs/';
     }
     if (isVersionGTE(version, MIN_WEBSITE_VERSION)) {
-      return `/docs/${version}/${pagePath}`;
+      return `/docs/${version}/`;
     }
     return `${REPO_URL}/${tag}/docs`;
   };
 
   // Dev docs live under /docs/dev/ once a stable release exists; before the
   // first release they remain at /docs/ (matches build-all.sh fallback).
-  const getDevUrl = () => {
-    const pagePath = getCurrentPagePath();
-    return latestTag ? `/docs/dev/${pagePath}` : `/docs/${pagePath}`;
-  };
+  const getDevUrl = () => (latestTag ? '/docs/dev/' : '/docs/');
 
   const isExternalLink = (tag: string) => {
     const version = tag.replace(/^v/, '');

--- a/preview/src/theme/DocVersionBanner/index.tsx
+++ b/preview/src/theme/DocVersionBanner/index.tsx
@@ -1,21 +1,18 @@
 import React from 'react';
-
-// Matches a versioned URL like /docs/0.7.0/... or /docs/1.2.3/...
-const VERSION_PATH_RE = /^\/docs\/\d+\.\d+(?:\.\d+)?\//;
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 export default function DocVersionBanner(): React.JSX.Element | null {
-  // This site deploys each version as a separate Docusaurus build rather than
-  // using Docusaurus's built-in multi-version feature, so the plugin version
-  // hooks always report "current". We detect the version from the URL instead.
-  const isVersionedPage =
-    typeof window !== 'undefined' && VERSION_PATH_RE.test(window.location.pathname);
+  const {siteConfig} = useDocusaurusContext();
 
-  // On a numbered-version page (e.g. /docs/0.7.0/...) — no banner needed.
-  if (isVersionedPage) {
+  // The dev build (baseUrl=/docs/dev/) is the only one that should advertise
+  // itself as a developer preview. The canonical /docs/ URL serves the latest
+  // stable release, and /docs/X.Y.Z/ URLs are explicit stable deep-links.
+  // Keying off baseUrl (a build-time constant) keeps the verdict consistent
+  // in SSR and after client hydration.
+  if (siteConfig.baseUrl !== '/docs/dev/') {
     return null;
   }
 
-  // On the dev (main) build — remind readers this is a preview.
   return (
     <div
       className="theme-doc-version-banner alert alert--warning margin-bottom--md"

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 # build-all.sh — Unified build script for local dev, Netlify, and GitHub Actions
 #
-# This script ensures consistency across all deployment environments by:
-# 1. Building the main site (landing page, blog, community)
-# 2. Syncing preview docs from upstream llm-d/llm-d repo
-# 3. Building the preview docs site
-# 4. Merging preview build into main build at /docs
-# 5. Building all release branches to /docs/{version}
+# Layout produced:
+#   build/                  — main site (landing, blog, community)
+#   build/docs/             — latest stable release docs (canonical URL)
+#   build/docs/{version}/   — every release-X.Y.Z branch (stable deep-links)
+#   build/docs/dev/         — development docs from llm-d/llm-d@<DEV_DOCS_BRANCH>
+#
+# If no release-X.Y.Z branches exist yet, dev docs are served at build/docs/
+# (preserving the historical pre-release behavior).
 #
 # Usage:
-#   ./scripts/build-all.sh                                        # clone from GitHub (main)
-#   ./scripts/build-all.sh release-0.7                           # clone from GitHub (branch)
-#   LLMD_REPO=/path/to/local/llm-d ./scripts/build-all.sh        # use local clone as-is
+#   ./scripts/build-all.sh                                        # dev docs from llm-d/llm-d@main
+#   ./scripts/build-all.sh release-0.7                            # dev docs from a different branch
+#   LLMD_REPO=/path/to/local/llm-d ./scripts/build-all.sh         # use local clone as-is
 #   LLMD_REPO=/path/to/local/llm-d LLMD_FETCH=1 ./scripts/build-all.sh  # fetch before sync
 
 set -euo pipefail
@@ -19,116 +21,143 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
-# Allow passing branch as first argument (defaults to main)
-DOCS_BRANCH="${1:-main}"
+# Branch in llm-d/llm-d that backs the "dev" docs (defaults to main)
+DEV_DOCS_BRANCH="${1:-main}"
 
 echo "========================================="
 echo "llm-d.ai Unified Build Script"
 echo "========================================="
 echo ""
 
-# Step 1: Build main site
-echo "Step 1/5: Building main site..."
+# Step 1: Build main site (landing, blog, community)
+echo "Step 1: Building main site..."
 cd "$PROJECT_DIR"
 npm run build
 echo "✓ Main site built to build/"
 echo ""
 
-# Step 2: Sync preview docs from upstream
-echo "Step 2/5: Syncing preview docs from llm-d/llm-d @ $DOCS_BRANCH..."
-cd "$PROJECT_DIR/preview"
-bash scripts/sync-docs.sh "$DOCS_BRANCH"
-echo "✓ Preview docs synced"
-echo ""
-
-# Step 3: Build preview docs site
-echo "Step 3/5: Building preview docs site..."
-cd "$PROJECT_DIR/preview"
-npm install
-npm run build
-echo "✓ Preview docs built to preview/build/"
-echo ""
-
-# Step 4: Merge preview into main build as /docs
-echo "Step 4/5: Merging preview build into main build at /docs..."
+# Step 2: Discover release branches and pick the latest stable
+echo "Step 2: Discovering release branches..."
 cd "$PROJECT_DIR"
-cp -r preview/build build/docs
-echo "✓ Preview merged to build/docs/"
+git fetch origin 2>/dev/null || true
+RELEASE_BRANCHES=$(git branch -r | grep 'origin/release-' | grep -v HEAD || true)
 
-# Also copy preview images to build/img/docs for absolute path references
-echo "   Copying preview images to build/img/docs for absolute paths..."
-mkdir -p build/img/docs
-cp -r preview/build/img/docs/* build/img/docs/
-echo "✓ Preview images copied to build/img/docs/"
+LATEST_VERSION=""
+if [ -n "$RELEASE_BRANCHES" ]; then
+  LATEST_VERSION=$(echo "$RELEASE_BRANCHES" | sed 's|.*origin/release-||' | sort -V | tail -1)
+  echo "Found release branches:"
+  echo "$RELEASE_BRANCHES"
+  echo "Latest stable: $LATEST_VERSION"
+else
+  echo "No release branches found"
+fi
 echo ""
+
+# When a stable release exists, dev moves under /docs/dev/ and /docs/ serves latest.
+# Without a stable release, dev keeps the canonical /docs/ URL.
+if [ -n "$LATEST_VERSION" ]; then
+  DEV_BASE_URL="/docs/dev/"
+  DEV_OUTPUT_SUBDIR="docs/dev"
+else
+  DEV_BASE_URL="/docs/"
+  DEV_OUTPUT_SUBDIR="docs"
+fi
+
+# Step 3: Build dev docs from llm-d/llm-d@$DEV_DOCS_BRANCH
+echo "Step 3: Syncing and building dev docs from llm-d/llm-d @ $DEV_DOCS_BRANCH..."
+echo "        Output: build/$DEV_OUTPUT_SUBDIR/ (baseUrl: $DEV_BASE_URL)"
+cd "$PROJECT_DIR/preview"
+bash scripts/sync-docs.sh "$DEV_DOCS_BRANCH"
+npm install
+DOCS_BASE_URL="$DEV_BASE_URL" npm run build
+cd "$PROJECT_DIR"
+mkdir -p "build/$DEV_OUTPUT_SUBDIR"
+cp -r preview/build/* "build/$DEV_OUTPUT_SUBDIR/"
+echo "✓ Dev docs built to build/$DEV_OUTPUT_SUBDIR/"
+
+# Expose preview images at /img/docs/ for absolute-path references in shared assets
+mkdir -p build/img/docs
+cp -r preview/build/img/docs/* build/img/docs/ 2>/dev/null || true
 
 # Optional: Include merge report if it exists (from GitHub Actions workflow)
 if [[ -n "${LLMD_REPO:-}" ]] && [[ -f "$LLMD_REPO/merge-report.txt" ]]; then
     echo "Including merge report..."
-    cp "$LLMD_REPO/merge-report.txt" build/docs/merge-report.txt
+    cp "$LLMD_REPO/merge-report.txt" "build/$DEV_OUTPUT_SUBDIR/merge-report.txt"
 fi
+echo ""
 
-# Step 5: Build and merge release branches
-echo "Step 5/5: Building release branches..."
-cd "$PROJECT_DIR"
-
-# Fetch all remote branches (needed for finding release branches)
-git fetch origin 2>/dev/null || true
-
-# Find all release branches (keep origin/ prefix for worktree refs)
-RELEASE_BRANCHES=$(git branch -r | grep 'origin/release-' | grep -v HEAD || true)
-
+# Step 4: Build release branches
 if [ -z "$RELEASE_BRANCHES" ]; then
-  echo "No release branches found, skipping"
+  echo "Step 4: No release branches to build"
 else
-  echo "Found release branches:"
-  echo "$RELEASE_BRANCHES"
-  echo ""
-
+  echo "Step 4: Building release branches..."
   for branch in $RELEASE_BRANCHES; do
-    # Extract version (e.g., origin/release-0.7.0 -> 0.7.0)
     VERSION=${branch#origin/release-}
+    if [ "$VERSION" = "$LATEST_VERSION" ]; then
+      IS_LATEST="yes"
+    else
+      IS_LATEST="no"
+    fi
 
-    echo "Building docs for version $VERSION from $branch"
+    echo ""
+    echo "Building docs for version $VERSION from $branch (latest: $IS_LATEST)"
 
-    # Checkout the release branch (in a worktree to avoid conflicts)
     WORKTREE_PATH="../release-${VERSION}"
-    # Clean up any existing worktree first to ensure fresh builds
     git worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
     git worktree add "$WORKTREE_PATH" "$branch" 2>/dev/null || {
       echo "⚠ Warning: Could not create worktree for $branch, skipping"
       continue
     }
 
-    # Build the release docs with version-specific baseUrl
+    # Override site UX (theme components, navbar, version dropdown, config)
+    # with main's copies so improvements propagate to every version. Doc
+    # CONTENT in preview/docs/ comes from the worktree and is left untouched.
+    echo "  Syncing UX from main into worktree..."
+    cp "$PROJECT_DIR/preview/docusaurus.config.ts" \
+       "${WORKTREE_PATH}/preview/docusaurus.config.ts"
+    rm -rf "${WORKTREE_PATH}/preview/src"
+    cp -r "$PROJECT_DIR/preview/src" "${WORKTREE_PATH}/preview/src"
+
     cd "${WORKTREE_PATH}/preview"
     npm install --silent
-    DOCS_BASE_URL=/docs/${VERSION}/ npm run build
 
-    # Copy build output to versioned path
+    # Always produce the versioned URL so external links remain stable
+    DOCS_BASE_URL=/docs/${VERSION}/ npm run build
     cd "$PROJECT_DIR"
     mkdir -p "build/docs/${VERSION}"
     cp -r "${WORKTREE_PATH}/preview/build/"* "build/docs/${VERSION}/"
+    echo "  ✓ Built /docs/${VERSION}/"
 
-    # Clean up worktree
+    # The latest stable is also served at /docs/ (the canonical URL)
+    if [ "$IS_LATEST" = "yes" ]; then
+      cd "${WORKTREE_PATH}/preview"
+      DOCS_BASE_URL=/docs/ npm run build
+      cd "$PROJECT_DIR"
+      cp -r "${WORKTREE_PATH}/preview/build/"* "build/docs/"
+      echo "  ✓ Built /docs/ (latest = $VERSION)"
+    fi
+
     git worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
-
-    echo "✓ Built version $VERSION"
-    echo ""
   done
 fi
 
+echo ""
 echo "========================================="
 echo "Build Complete!"
 echo "========================================="
 echo ""
 echo "Output directory: build/"
-echo "  - Main site: build/"
-echo "  - Docs site: build/docs/"
-if [ -n "${RELEASE_BRANCHES:-}" ]; then
+echo "  - Main site:       build/"
+if [ -n "$LATEST_VERSION" ]; then
+  echo "  - /docs/           latest stable ($LATEST_VERSION)"
+  echo "  - /docs/dev/       development (from llm-d/llm-d@$DEV_DOCS_BRANCH)"
+else
+  echo "  - /docs/           development (from llm-d/llm-d@$DEV_DOCS_BRANCH)"
+fi
+if [ -n "$RELEASE_BRANCHES" ]; then
   for branch in $RELEASE_BRANCHES; do
     VERSION=${branch#origin/release-}
-    echo "  - Version $VERSION: build/docs/$VERSION/"
+    echo "  - /docs/$VERSION/"
   done
 fi
 echo ""


### PR DESCRIPTION
## What does this PR do?

Previously /docs/ rendered the dev (main) docs, which is dangerous because main can include documentation for features that have not shipped yet. Now /docs/ serves the latest released branch and dev docs live at /docs/dev/, reachable via the version dropdown.

URL layout
----------
- /docs/           latest stable (the highest release-X.Y.Z branch),
                   built with DOCS_BASE_URL=/docs/
- /docs/dev/       development (llm-d/llm-d@main),
                   built with DOCS_BASE_URL=/docs/dev/
- /docs/X.Y.Z/     every release-X.Y.Z, kept working as stable
                   deep-links (the highest version is also mirrored
                   at the canonical /docs/ URL)

Before any release-X.Y.Z branches exist, dev docs continue to be served at /docs/ as a fallback, preserving the historical pre-launch behavior.

Implementation notes
--------------------
- scripts/build-all.sh discovers release branches, picks the highest via `sort -V`, and decides whether dev goes to /docs/dev/ or /docs/. For every release-branch worktree it also overrides preview/src/ and preview/docusaurus.config.ts with main's copies before building, so site-wide UX changes (version dropdown, dev banner, navbar) ship to every versioned URL without per-release backports. Doc content in preview/docs/ stays untouched.
- preview/src/components/VersionDropdown.tsx routes the latest tag to the canonical /docs/{page} URL, sends "dev" to /docs/dev/{page}, and preserves the current page path on switch. The dropdown entry is renamed from "dev (main)" to "dev".
- preview/src/theme/DocVersionBanner shows the "developer preview" banner only when siteConfig.baseUrl === '/docs/dev/', so it no longer leaks onto /docs/ or /docs/X.Y.Z/ (the previous URL-regex check fell through to "show banner" during SSR and on any non-versioned URL).
- preview/RELEASE-BRANCH-SYNC.md and preview/VERSIONING.md describe the new layout; the explanatory comment in preview/docusaurus.config.ts is updated accordingly.

## Why is this change needed?

See #301 

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build`)
- [x] Manual testing performed (`npm start`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build`)
- [ ] Documentation updated (if applicable)

## Related Issues
#301 