### PR TITLE
fix(docs): hide pre-0.7 versions from the version dropdown

### DIFF
--- a/preview/src/components/VersionDropdown.tsx
+++ b/preview/src/components/VersionDropdown.tsx
@@ -58,7 +58,14 @@ export default function VersionDropdown(): React.JSX.Element {
 
   const latestTag = releases?.[0];
   const latestVersion = latestTag?.replace(/^v/, '');
-  const olderReleases = releases?.slice(1) || [];
+  // Only show versions that are hosted on the website (>= MIN_WEBSITE_VERSION).
+  // Pre-0.7.0 docs live in GitHub and would otherwise render as external
+  // GitHub links in the dropdown, which is noisy and inconsistent with the
+  // rest of the navigation. When a future release ships, the previous one
+  // will naturally drop into this list as the new latest takes the top slot.
+  const olderReleases = (releases?.slice(1) || []).filter((tag) =>
+    isVersionGTE(tag.replace(/^v/, ''), MIN_WEBSITE_VERSION),
+  );
 
   // Detect current version from the actual browser URL (window.location.pathname).
   // useLocation() returns a path relative to Docusaurus's baseUrl, which strips


### PR DESCRIPTION
## What does this PR do?

Pre-0.7 versions don't have website-hosted docs (their content lives in the upstream llm-d/llm-d repo under git tags), so the dropdown was rendering them as external GitHub links — visually noisy and inconsistent with the rest of the in-site navigation.

Filter olderReleases down to versions >= MIN_WEBSITE_VERSION (0.7.0). The "latest" slot continues to come from releases[0] automatically, so when 0.8 ships, the dropdown becomes "dev | latest (v0.8.0) | v0.7.0" with no extra wiring.

## Why is this change needed?

#299 

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build`)
- [x] Manual testing performed (`npm start`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build`)
- [ ] Documentation updated (if applicable)

## Related Issues

#299 
