### PR TITLE
fix(docs): collapse the docs sidebar by default

### DIFF
--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -18,7 +18,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Architecture',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'architecture/index'},
       items: [
         {
@@ -195,7 +195,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Resources',
-      collapsed: false,
+      collapsed: true,
       items: [
         {
           type: 'category',
@@ -238,7 +238,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'API Reference',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'api-reference/index'},
       items: [
         'api-reference/glossary',


### PR DESCRIPTION
## What does this PR do?

Flips the top-level sidebar categories in `preview/sidebars.ts` so that only **Getting Started** and **Guides** stay expanded by default. **Architecture**, **Resources**, and **API Reference** are now collapsed by default (`collapsed: true`). Users can click any of them to expand, and Docusaurus still auto-expands the parent of the current page on navigation.

This PR controls `/docs/dev/`. A companion PR against the `release-0.7.0` branch makes the same change for `/docs/` and `/docs/0.7.0/`.


## Why is this change needed?

The sidebar previously rendered every top-level category in its expanded state, which produces a long initial scroll, makes it hard to see the full set of sections at a glance, and buries the "getting started → guides" path that most new readers actually want. Collapsing the lower-traffic categories keeps the navigation compact and oriented toward the common entry path.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build`)
- [x] Manual testing performed (`npm start`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
