### PR TITLE
fix(docs): collapse the docs sidebar by default

### DIFF
--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -18,7 +18,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Architecture',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'architecture/index'},
       items: [
         {
@@ -122,7 +122,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Resources',
-      collapsed: false,
+      collapsed: true,
       items: [
         {
           type: 'category',
@@ -165,7 +165,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'API Reference',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'api-reference/index'},
       items: [
         'api-reference/glossary',


### PR DESCRIPTION
Only "Getting Started" and "Guides" stay expanded; "Architecture", "Resources", and "API Reference" are collapsed by default. Mirrors the equivalent change on main so /docs/ (built from release-0.7.0) matches /docs/dev/ behavior.

## What does this PR do?

Companion to the equivalent change on `main`. Flips the top-level sidebar categories in `preview/sidebars.ts` so that only **Getting Started** and **Guides** stay expanded by default; **Architecture**, **Resources**, and **API Reference** are collapsed (`collapsed: true`).

`release-0.7.0` is what `/docs/` (canonical) and `/docs/0.7.0/` are built from, so the change needs to land here for the collapsed-by-default behavior to show up on the live latest-stable docs.

## Why is this change needed?

The sidebar previously rendered every top-level category expanded, producing a long initial scroll and burying the common "getting started → guides" entry path that most new readers want. Collapsing the lower-traffic categories keeps the navigation compact.

A matching PR against `main` covers `/docs/dev/` so dev and latest stay in sync.
## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build`)
- [x] Manual testing performed (`npm start`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
