### PR TITLE
docs: fix inference simulator archive typos

### DIFF
--- a/docs-archive-pre-v0.7/architecture/Components/inference-sim.md
+++ b/docs-archive-pre-v0.7/architecture/Components/inference-sim.md
@@ -27,7 +27,7 @@ Running full LLM inference requires significant GPU resources and introduces non
 
 The simulator is designed to act as a drop-in replacement for vLLM, sitting between your client/infrastructure and the void where the GPU usually resides. It processes requests through a configurable simulation engine that governs what is returned and when it is returned.
 
-For detailed configuraiton definitions see the [Configuration Guide](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/configuration.md)
+For detailed configuration definitions see the [Configuration Guide](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/configuration.md)
 
 ### Modes of Operation
 The simulator decides the content of the response based on two primary modes:
@@ -93,7 +93,7 @@ The simulator is designed to run either as a standalone binary or within a Kuber
 ### Observability
 The simulator supports a subset of standard vLLM Prometheus metrics.<br />
 
-For detailes see the [Metrics Guide](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/metrics.md)
+For details see the [Metrics Guide](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/metrics.md)
 
 ## Working with docker image
 


### PR DESCRIPTION
## Problem
Issue #214 tracks typo-checker findings in the docs site. The archived inference simulator page contains two straightforward prose typos: `configuraiton` and `detailes`.

## Solution
Correct those two typos in `docs-archive-pre-v0.7/architecture/Components/inference-sim.md`.

I intentionally left acronym-like checker findings such as `ND`, `IST`, and `MAPE` untouched because they may be domain-specific or otherwise ambiguous.

## Validation
- `git diff --check`
- `git grep -n -E 'configuraiton|detailes'` returns no matches

Confidence: 82/100 (docs/typo)

Related: #214