### PR TITLE
fix(footer): point Documentation footer links at real URLs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -226,13 +226,13 @@ const config = {
             title: "Documentation",
             items: [
               {
-                html: '<a href="/docs/getting-started/index" class="footer__link-item">Getting Started</a>',
+                html: '<a href="/docs/getting-started" class="footer__link-item">Getting Started</a>',
               },
               {
-                html: '<a href="/docs/architecture/index" class="footer__link-item">Architecture</a>',
+                html: '<a href="/docs/architecture" class="footer__link-item">Architecture</a>',
               },
               {
-                html: '<a href="/docs/guides/index" class="footer__link-item">Guides</a>',
+                html: '<a href="/docs/guides" class="footer__link-item">Guides</a>',
               },
             ],
           },


### PR DESCRIPTION
The Getting Started, Architecture, and Guides entries in the footer's Documentation column linked to /docs/{section}/index, which 404s. The actual served URLs are /docs/{section} (no trailing /index).

## What does this PR do?

Drops the trailing `/index` from the **Getting Started**, **Architecture**, and **Guides** links in the footer's Documentation column. The actual served URLs are `/docs/getting-started`, `/docs/architecture`, and `/docs/guides`; the previous `/docs/{section}/index` paths 404.

## Why is this change needed?

The footer links were silently broken — every click from the footer's Documentation column landed on the 404 page. The fix is a three-line URL correction in `docusaurus.config.js`.
## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build`)
- [ x Manual testing performed (`npm start`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
