### PR TITLE
docs: fix inference simulator typos

### DIFF
--- a/docs-archive-pre-v0.7/architecture/Components/inference-sim.md
+++ b/docs-archive-pre-v0.7/architecture/Components/inference-sim.md
@@ -27,7 +27,7 @@ Running full LLM inference requires significant GPU resources and introduces non
 
 The simulator is designed to act as a drop-in replacement for vLLM, sitting between your client/infrastructure and the void where the GPU usually resides. It processes requests through a configurable simulation engine that governs what is returned and when it is returned.
 
-For detailed configuraiton definitions see the [Configuration Guide](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/configuration.md)
+For detailed configuration definitions see the [Configuration Guide](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/configuration.md)
 
 ### Modes of Operation
 The simulator decides the content of the response based on two primary modes:
@@ -93,7 +93,7 @@ The simulator is designed to run either as a standalone binary or within a Kuber
 ### Observability
 The simulator supports a subset of standard vLLM Prometheus metrics.<br />
 
-For detailes see the [Metrics Guide](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/metrics.md)
+For details see the [Metrics Guide](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/metrics.md)
 
 ## Working with docker image
 


### PR DESCRIPTION
## Summary
- fix two typo-checker findings in the archived inference simulator docs (`configuraiton` and `detailes`)

## Notes
- I intentionally left the `MAPE` acronym and timestamp `IST` entries unchanged because they appear to be valid terms rather than typos.

## Validation
- `python3` assertions verified the misspellings are absent and corrected phrases are present
- `git diff --check -- docs-archive-pre-v0.7/architecture/Components/inference-sim.md`

Related: #214

Confidence: 78/100 (docs/typo)