### PR TITLE
fix(sync): copy gateway docs from guides/prereq/gateways on dev sync

### DIFF
--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -170,6 +170,12 @@ cp_doc "$WIP/resources/monitoring/tracing.md"               "$DOCS_DIR/resources
 cp_doc "$WIP/guides/monitoring/metrics.md"                  "$DOCS_DIR/resources/monitoring/metrics.md"
 cp_doc "$WIP/guides/monitoring/tracing.md"                  "$DOCS_DIR/resources/monitoring/tracing.md"
 
+# PR llm-d/llm-d#1259 moved gateway docs to guides/prereq/gateways/
+cp_doc "$SRC/guides/prereq/gateways/README.md"              "$DOCS_DIR/resources/gateway/index.md"
+cp_doc "$SRC/guides/prereq/gateways/istio.md"               "$DOCS_DIR/resources/gateway/istio.md"
+cp_doc "$SRC/guides/prereq/gateways/gke.md"                 "$DOCS_DIR/resources/gateway/gke.md"
+cp_doc "$SRC/guides/prereq/gateways/agentgateway.md"        "$DOCS_DIR/resources/gateway/agentgateway.md"
+
 cp_doc "$WIP/resources/rdma/README.md"                      "$DOCS_DIR/resources/rdma/rdma-configuration.md"
 
 # === Infrastructure Providers ===


### PR DESCRIPTION
main's sync-docs.sh was missing the four cp_doc lines that pull the gateway content from upstream guides/prereq/gateways/ into $DOCS_DIR/resources/gateway/. The directory was mkdir'd and the stub generator filled it with "Work in Progress" placeholders, so /docs/dev/resources/gateway/{,istio,gke,agentgateway} all rendered stubs instead of the real content. /docs/ (built from release-0.7.0) was fine because that branch's sync-docs.sh still has the copies.

Adds the same four cp_doc lines so dev mirrors
https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateways.

## What does this PR do?

Adds four `cp_doc` lines to `preview/scripts/sync-docs.sh` so the dev sync copies the upstream `guides/prereq/gateways/{README,istio,gke,agentgateway}.md` into `$DOCS_DIR/resources/gateway/`. Identical to the lines `release-0.7.0`'s `sync-docs.sh` already has.

## Why is this change needed?

`/docs/dev/resources/gateway` (and `/istio`, `/gke`, `/agentgateway`) were rendering the auto-generated "Work in Progress" stubs because `main`'s `sync-docs.sh` only `mkdir`'d the destination directory and never copied any source files into it — the stub generator at the end of the script then filled the empty paths with placeholders.

`/docs/resources/gateway` (built from `release-0.7.0`) was fine because that branch's `sync-docs.sh` still has the copy lines. This PR brings `main` to parity so dev mirrors https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateways.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build`)
- [x] Manual testing performed (`npm start`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #315 
