### PR TITLE
Remove last references to inference scheduler

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -69,7 +69,7 @@ import Link from '@docusaurus/Link';
       boxShadow: '0 2px 8px rgba(0,0,0,0.1)'
     }
   }}>
-    <h4 style={{margin: '0 0 8px 0', color: 'var(--ifm-color-primary)'}}>Routing</h4>
+    <h4 style={{margin: '0 0 8px 0', color: 'var(--ifm-color-primary)'}}>Router</h4>
     <p style={{margin: '0', fontSize: '14px'}}>Intelligent request routing and load balancing</p>
   </Link>
   

--- a/community/index.md
+++ b/community/index.md
@@ -55,7 +55,7 @@ import Link from '@docusaurus/Link';
   gap: '16px',
   marginTop: '16px'
 }}>
-  <Link to="/community/sigs#sig-inference-scheduler" style={{
+  <Link to="/community/sigs#sig-router-formerly-inference-scheduler" style={{
     padding: '16px',
     border: '1px solid var(--ifm-color-emphasis-200)',
     borderRadius: '8px',
@@ -69,7 +69,7 @@ import Link from '@docusaurus/Link';
       boxShadow: '0 2px 8px rgba(0,0,0,0.1)'
     }
   }}>
-    <h4 style={{margin: '0 0 8px 0', color: 'var(--ifm-color-primary)'}}>Inference Scheduler</h4>
+    <h4 style={{margin: '0 0 8px 0', color: 'var(--ifm-color-primary)'}}>Routing</h4>
     <p style={{margin: '0', fontSize: '14px'}}>Intelligent request routing and load balancing</p>
   </Link>
   

--- a/preview/docusaurus.config.ts
+++ b/preview/docusaurus.config.ts
@@ -158,7 +158,7 @@ const config: Config = {
           title: 'Repositories',
           items: [
             {label: 'llm-d', href: 'https://github.com/llm-d/llm-d'},
-            {label: 'Inference Scheduler', href: 'https://github.com/llm-d/llm-d-inference-scheduler'},
+            {label: 'Router', href: 'https://github.com/llm-d/llm-d-router'},
             {label: 'KV Cache', href: 'https://github.com/llm-d/llm-d-kv-cache'},
           ],
         },

--- a/preview/scripts/test-fixtures/transformation-test.expected.md
+++ b/preview/scripts/test-fixtures/transformation-test.expected.md
@@ -122,6 +122,14 @@ Images with relative paths should be transformed:
 
 This should escape arrows: \<->
 
+## 6b. Autolink Test
+
+Bare HTTPS autolink: https://github.com/llm-d/llm-d/issues/680
+
+Bare HTTP autolink: http://example.com/path/to/page
+
+A link already in markdown format should be unchanged: [llm-d](https://github.com/llm-d)
+
 ## 7. HTML Image Tag Test
 
 Images with unquoted attributes should be quoted for MDX:

--- a/preview/scripts/test-fixtures/transformation-test.md
+++ b/preview/scripts/test-fixtures/transformation-test.md
@@ -96,6 +96,14 @@ Images with relative paths should be transformed:
 
 This should escape arrows: <->
 
+## 6b. Autolink Test
+
+Bare HTTPS autolink: <https://github.com/llm-d/llm-d/issues/680>
+
+Bare HTTP autolink: <http://example.com/path/to/page>
+
+A link already in markdown format should be unchanged: [llm-d](https://github.com/llm-d)
+
 ## 7. HTML Image Tag Test
 
 Images with unquoted attributes should be quoted for MDX:

--- a/preview/scripts/transformations.sh
+++ b/preview/scripts/transformations.sh
@@ -41,6 +41,10 @@ apply_transformations() {
     # MDX escaping - escape special characters
     sed_inplace 's|<->|\\<->|g' "$file"
 
+    # Convert autolinks (<https://...> / <http://...>) to plain URLs
+    # MDX parses angle brackets as JSX and fails on the / in URLs
+    sed_inplace -E 's|<(https?://[^>]+)>|\1|g' "$file"
+
     # Escape HTML comments for MDX (MDX doesn't support <!-- --> syntax)
     # Replace HTML comments with MDX comments: <!-- text --> becomes {/* text */}
     # Handle both single-line and multi-line comments


### PR DESCRIPTION

## What does this PR do?

Fixes missing links and completes name change from inference scheduler to router.

## How was this tested?

- [x] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build`)
- [x] Manual testing performed (`npm start`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build`)
- [x] Documentation updated (if applicable)

## Related Issues

fixes #319 
