### PR TITLE
Correct the guide/well lit paths paths structure on main (dev)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,15 +10,17 @@
 
 <!-- Describe how you verified the changes work correctly -->
 - [ ] Tests added/updated (`npm test`)
-- [ ] Site builds successfully (`npm run build`)
-- [ ] Manual testing performed (`npm start`)
+- [ ] Site builds successfully (`npm run build:all`)
+- [ ] Check links after buildling (`npm run check-links`)
+- [ ] Manual testing performed (`npm run serve`)
 
 ## Checklist
 
 - [ ] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
 - [ ] Code follows project [contributing guidelines](../CONTRIBUTING.md)
 - [ ] Tests pass locally (`npm test`)
-- [ ] Site builds without errors (`npm run build`)
+- [ ] Site builds without errors (`npm run build:all`)
+- [ ] No broken links after building full site (`npm run check-links`)
 - [ ] Documentation updated (if applicable)
 
 ## Related Issues

--- a/preview/docusaurus.config.ts
+++ b/preview/docusaurus.config.ts
@@ -90,14 +90,36 @@ const config: Config = {
             // directory-based guides (*/index.md at depth >2) come from guides/*/README.md
             if (cleanPath.startsWith('guides/')) {
               const parts = cleanPath.split('/');
+              const flatGuideToWellLitFile: Record<string, string> = {
+                'precise-prefix-cache-aware.md': 'precise-prefix-cache-routing',
+                'predicted-latency-routing.md': 'predicted-latency',
+                'wide-ep-lws.md': 'wide-expert-parallelism',
+                'batch-gateway.md': 'experimental/batch-gateway',
+              };
+              const guideDirToWellLitFile: Record<string, string> = {
+                'optimized-baseline': 'optimized-baseline',
+                'precise-prefix-cache-routing': 'precise-prefix-cache-routing',
+                'tiered-prefix-cache': 'tiered-prefix-cache',
+                'asynchronous-processing': 'asynchronous-processing',
+                'flow-control': 'flow-control',
+                'pd-disaggregation': 'pd-disaggregation',
+                'predicted-latency-routing': 'predicted-latency',
+                'wide-ep-lws': 'wide-expert-parallelism',
+                'workload-autoscaling': 'workload-autoscaling',
+                'no-kubernetes-deployment': 'no-kubernetes-deployment',
+              };
               if (cleanPath.endsWith('/index.md') && parts.length > 2) {
-                // Directory-based guide: guides/[name]/index.md → guides/[name]/README.md
+                const wellLitFile = guideDirToWellLitFile[parts[1]];
+                if (wellLitFile) {
+                  return `https://github.com/llm-d/llm-d/blob/main/docs/well-lit-paths/${wellLitFile}.md`;
+                }
+                // Non Well-Lit directory content (e.g. recipes) still lives under guides/
                 return `https://github.com/llm-d/llm-d/blob/main/${sourcePath}`;
               }
-              // Flat overview page synced from docs/well-lit-paths/
-              // Special case: precise-prefix-cache-aware was renamed to precise-prefix-cache-routing
-              if (cleanPath === 'guides/precise-prefix-cache-aware.md') {
-                return 'https://github.com/llm-d/llm-d/blob/main/docs/well-lit-paths/precise-prefix-cache-routing.md';
+              const flatGuideName = parts[1];
+              const flatWellLitFile = flatGuideToWellLitFile[flatGuideName];
+              if (flatWellLitFile) {
+                return `https://github.com/llm-d/llm-d/blob/main/docs/well-lit-paths/${flatWellLitFile}.md`;
               }
               const wellLitPath = sourcePath.replace(/^guides\//, 'docs/well-lit-paths/');
               return `https://github.com/llm-d/llm-d/blob/main/${wellLitPath}`;
@@ -207,7 +229,7 @@ const config: Config = {
           items: [
             {label: 'Getting Started', to: '/getting-started'},
             {label: 'Architecture', to: '/architecture'},
-            {label: 'Guides', to: '/guides'},
+            {label: 'Well-Lit Paths', to: '/guides'},
             {label: 'Resources', to: '/resources/gateway'},
           ],
         },

--- a/preview/docusaurus.config.ts
+++ b/preview/docusaurus.config.ts
@@ -63,6 +63,20 @@ const config: Config = {
 
   plugins: [
     require.resolve('./plugins/versions-plugin'),
+    [
+      require.resolve('@docusaurus/plugin-client-redirects'),
+      {
+        createRedirects(existingPath: string) {
+          if (existingPath.startsWith('/well-lit-paths')) {
+            return [existingPath.replace('/well-lit-paths', '/guides')];
+          }
+          if (existingPath.startsWith('/guides')) {
+            return [existingPath.replace('/guides', '/well-lit-paths')];
+          }
+          return undefined;
+        },
+      },
+    ],
     // Build docs search output so the site-root merge step can compose a
     // unified index from build/search-doc.json + build/docs/search-doc.json.
     [
@@ -229,7 +243,7 @@ const config: Config = {
           items: [
             {label: 'Getting Started', to: '/getting-started'},
             {label: 'Architecture', to: '/architecture'},
-            {label: 'Well-Lit Paths', to: '/guides'},
+            {label: 'Well-Lit Paths', to: '/well-lit-paths'},
             {label: 'Resources', to: '/resources/gateway'},
           ],
         },

--- a/preview/package-lock.json
+++ b/preview/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/faster": "3.10.1",
+        "@docusaurus/plugin-client-redirects": "^3.10.1",
         "@docusaurus/preset-classic": "3.10.1",
         "@docusaurus/theme-mermaid": "^3.10.1",
         "@fontsource/inter": "^5.2.8",
@@ -3708,6 +3709,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz",
+      "integrity": "sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/preview/package.json
+++ b/preview/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@docusaurus/core": "3.10.1",
     "@docusaurus/faster": "3.10.1",
+    "@docusaurus/plugin-client-redirects": "^3.10.1",
     "@docusaurus/preset-classic": "3.10.1",
     "@docusaurus/theme-mermaid": "^3.10.1",
     "@fontsource/inter": "^5.2.8",

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -20,6 +20,47 @@ cp_doc() {
     fi
 }
 
+set_doc_slug() {
+    local file="$1"
+    local slug="$2"
+
+    if [[ ! -f "$file" ]]; then
+        return
+    fi
+
+    local first_line
+    IFS= read -r first_line < "$file" || true
+
+    if [[ "$first_line" == "---" ]]; then
+        awk -v slug="$slug" '
+            BEGIN {in_frontmatter=1; slug_set=0}
+            NR==1 {print; next}
+            in_frontmatter==1 && /^---$/ {
+                if (!slug_set) {
+                    print "slug: " slug
+                }
+                print
+                in_frontmatter=0
+                next
+            }
+            in_frontmatter==1 && /^slug:[[:space:]]*/ {
+                print "slug: " slug
+                slug_set=1
+                next
+            }
+            {print}
+        ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+        return
+    fi
+
+    {
+        printf -- "---\n"
+        printf -- "slug: %s\n" "$slug"
+        printf -- "---\n\n"
+        cat "$file"
+    } > "$file.tmp" && mv "$file.tmp" "$file"
+}
+
 BRANCH="${1:-main}"
 REPO_URL="https://github.com/llm-d/llm-d.git"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -151,6 +192,21 @@ sed_inplace \
     -e 's|\](experimental/batch-gateway\.md)|\](/guides/batch-gateway)|g' \
     -e 's|\](no-kubernetes-deployment\.md)|\](/guides/no-kubernetes-deployment)|g' \
     "$DOCS_DIR/guides/index.md"
+
+# Publish well-lit paths at /well-lit-paths/* while keeping source files and doc IDs
+# under docs/guides/* for sync/edit compatibility.
+set_doc_slug "$DOCS_DIR/guides/index.md" "/well-lit-paths"
+set_doc_slug "$DOCS_DIR/guides/optimized-baseline.md" "/well-lit-paths/optimized-baseline"
+set_doc_slug "$DOCS_DIR/guides/precise-prefix-cache-routing.md" "/well-lit-paths/precise-prefix-cache-routing"
+set_doc_slug "$DOCS_DIR/guides/tiered-prefix-cache.md" "/well-lit-paths/tiered-prefix-cache"
+set_doc_slug "$DOCS_DIR/guides/asynchronous-processing.md" "/well-lit-paths/asynchronous-processing"
+set_doc_slug "$DOCS_DIR/guides/flow-control.md" "/well-lit-paths/flow-control"
+set_doc_slug "$DOCS_DIR/guides/pd-disaggregation.md" "/well-lit-paths/pd-disaggregation"
+set_doc_slug "$DOCS_DIR/guides/predicted-latency.md" "/well-lit-paths/predicted-latency"
+set_doc_slug "$DOCS_DIR/guides/wide-expert-parallelism.md" "/well-lit-paths/wide-expert-parallelism"
+set_doc_slug "$DOCS_DIR/guides/workload-autoscaling.md" "/well-lit-paths/workload-autoscaling"
+set_doc_slug "$DOCS_DIR/guides/no-kubernetes-deployment.md" "/well-lit-paths/no-kubernetes-deployment"
+set_doc_slug "$DOCS_DIR/guides/batch-gateway.md" "/well-lit-paths/batch-gateway"
 
 # === Resources / Observability ===
 # llm-d/llm-d#1542: docs/resources/observability/ (setup, metrics, tracing, promql).
@@ -571,6 +627,17 @@ done
 echo "    Fixing /img/docs/images/ paths..."
 find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
     sed_inplace 's|/img/docs/images/|/img/docs/|g' "$file"
+done
+
+# === Canonicalize in-site guide links to /well-lit-paths ===
+echo "    Canonicalizing /guides links to /well-lit-paths..."
+find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
+    sed_inplace \
+        -e 's|\](/docs/guides/\([^)]*\))|\](/docs/well-lit-paths/\1)|g' \
+        -e 's|\](/docs/guides)|\](/docs/well-lit-paths)|g' \
+        -e 's|\](/guides/\([^)]*\))|\](/well-lit-paths/\1)|g' \
+        -e 's|\](/guides)|\](/well-lit-paths)|g' \
+        "$file"
 done
 
 # === Rewrite upstream repo links to the synced branch ===

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -279,8 +279,6 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|getting-started/README\.md|getting-started/index.md|g' \
         -e 's|api-reference/README\.md|api-reference/index.md|g' \
         -e 's|resources/rdma/README\.md|resources/rdma/rdma-configuration.md|g' \
-        -e 's|advanced/disaggregation\.md|advanced/disaggregation/index.md|g' \
-        -e 's|advanced/autoscaling/autoscaling\.md|advanced/autoscaling/index.md|g' \
         -e 's|advanced/batch/README\.md|advanced/batch/index.md|g' \
         -e 's|\](/docs/guides/README)|\](/docs/guides)|g' \
         -e 's|\](/docs/experimental/batch-gateway)|\](/guides/batch-gateway)|g' \
@@ -292,20 +290,18 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](/docs/infra-providers)|\](/docs/resources/infra-providers)|g' \
         -e 's|\](infra-providers/\([^)]*\))|\](/resources/infra-providers/\1)|g' \
         -e 's|\](/docs/\([^)]*\)/README\.md)|\](/docs/\1)|g' \
-        -e 's|\](/docs/guides/predicted-latency-based-scheduling)|\](/docs/guides/predicted-latency)|g' \
-        -e 's|\](/guides/predicted-latency-based-scheduling)|\](/guides/predicted-latency)|g' \
-        -e 's|\](/docs/guides/no-kubernetes-deployment)|\](/guides/no-kubernetes-deployment)|g' \
-        -e 's|\](/docs/guides/precise-prefix-cache-routing)|\](/guides/precise-prefix-cache-routing)|g' \
-        -e 's|\](/docs/guides/predicted-latency)|\](/guides/predicted-latency)|g' \
-        -e 's|\](/docs/guides/wide-expert-parallelism)|\](/guides/wide-expert-parallelism)|g' \
-        -e 's|\](/docs/guides/batch-gateway)|\](/guides/batch-gateway)|g' \
-        -e 's|llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/profile)|llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/profilehandler)|g' \
-        -e 's|\](/docs/guides/predicted-latency-routing)|\](/docs/guides/predicted-latency)|g' \
-        -e 's|\](/guides/predicted-latency-routing)|\](/guides/predicted-latency)|g' \
-        -e 's|\](../../guides/predicted-latency-routing)|\](/guides/predicted-latency)|g' \
-        -e 's|\](/docs/guides/wide-ep-lws)|\](/docs/guides/wide-expert-parallelism)|g' \
-        -e 's|\](/guides/wide-ep-lws)|\](/guides/wide-expert-parallelism)|g' \
-        -e 's|\](../../guides/wide-ep-lws)|\](/guides/wide-expert-parallelism)|g' \
+        -e 's|\](../../guides/optimized-baseline)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline)|g' \
+        -e 's|\](../../guides/precise-prefix-cache-routing)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-routing)|g' \
+        -e 's|\](../../guides/tiered-prefix-cache)|\](https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache)|g' \
+        -e 's|\](../../guides/asynchronous-processing)|\](https://github.com/llm-d/llm-d/tree/main/guides/asynchronous-processing)|g' \
+        -e 's|\](../../guides/flow-control)|\](https://github.com/llm-d/llm-d/tree/main/guides/flow-control)|g' \
+        -e 's|\](../../guides/pd-disaggregation)|\](https://github.com/llm-d/llm-d/tree/main/guides/pd-disaggregation)|g' \
+        -e 's|\](../../guides/predicted-latency-routing)|\](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-routing)|g' \
+        -e 's|\](../../guides/wide-ep-lws)|\](https://github.com/llm-d/llm-d/tree/main/guides/wide-ep-lws)|g' \
+        -e 's|\](../../guides/workload-autoscaling)|\](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling)|g' \
+        -e 's|\](../../guides/no-kubernetes-deployment)|\](https://github.com/llm-d/llm-d/tree/main/guides/no-kubernetes-deployment)|g' \
+        -e 's|\](../../../guides/batch-gateway)|\](https://github.com/llm-d/llm-d/tree/main/guides/batch-gateway)|g' \
+        -e 's|\](../../../guides/asynchronous-processing)|\](https://github.com/llm-d/llm-d/tree/main/guides/asynchronous-processing)|g' \
         -e 's|\](../../../../guides/tiered-prefix-cache)|\](/guides/tiered-prefix-cache)|g' \
         -e 's|\](/guides/tiered-prefix-cache)|\](/guides/tiered-prefix-cache)|g' \
         -e 's|\](../../../../guides/batch-gateway)|\](/guides/batch-gateway)|g' \
@@ -313,10 +309,6 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](../../../guides/batch-gateway)|\](/guides/batch-gateway)|g' \
         -e 's|\](../../../guides/asynchronous-processing)|\](/guides/asynchronous-processing)|g' \
         -e 's|\](../../guides/pd-disaggregation/README\.md)|\](/guides/pd-disaggregation)|g' \
-        -e 's|\](../../guides/no-kubernetes-deployment)|\](/guides/no-kubernetes-deployment)|g' \
-        -e 's|\](../../guides/precise-prefix-cache-routing)|\](/guides/precise-prefix-cache-routing)|g' \
-        -e 's|\](../../getting-started/quickstart\.md)|\](/getting-started/quickstart)|g' \
-        -e 's|\](../../architecture/advanced/batch/batch-gateway\.md)|\](/architecture/advanced/batch/batch-gateway)|g' \
         "$file"
 done
 

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -120,49 +120,36 @@ cp_doc "$WIP/architecture/advanced/batch/README.md"           "$DOCS_DIR/archite
 cp_doc "$WIP/architecture/advanced/batch/batch-gateway.md"    "$DOCS_DIR/architecture/advanced/batch/batch-gateway.md"
 cp_doc "$WIP/architecture/advanced/batch/async-processor.md"  "$DOCS_DIR/architecture/advanced/batch/async-processor.md"
 
-# === Guides ===
-echo "    Copying detailed guide README.md files from guides/..."
+# === Well-Lit Paths ===
+echo "    Copying well-lit-paths overview pages..."
 
-find "$SRC/guides" -name "README.md" -type f 2>/dev/null | grep -v "/prereq/" | grep -v "/experimental/" | while read -r readme_file; do
-    rel_path="${readme_file#$SRC/guides/}"
-    dst_path="$DOCS_DIR/guides/${rel_path%README.md}index.md"
-    mkdir -p "$(dirname "$dst_path")"
-    cp "$readme_file" "$dst_path"
-done
-
-# Fix unclosed tab blocks in upstream content
-echo "    Fixing unclosed tab blocks..."
-# experimental-dp-aware has <!-- TABS:START --> and <!-- TAB:CoreWeave --> but missing <!-- TABS:END -->
-# The tab should close after the kubectl command, before "### Deploy InferencePool"
-if [[ -f "$DOCS_DIR/guides/wide-ep-lws/experimental-dp-aware/index.md" ]]; then
-    # Insert <!-- TABS:END --> before the "### Deploy InferencePool" heading
-    sed_inplace '/^### Deploy InferencePool$/i\
-<!-- TABS:END -->\
-' "$DOCS_DIR/guides/wide-ep-lws/experimental-dp-aware/index.md"
-fi
-
-echo "    Copying well-lit-paths overview pages as fallback..."
-
-cp_doc "$WIP/well-lit-paths/README.md" "$DOCS_DIR/guides/index.md"
+cp_doc "$WIP/well-lit-paths/README.md"                      "$DOCS_DIR/guides/index.md"
+cp_doc "$WIP/well-lit-paths/optimized-baseline.md"          "$DOCS_DIR/guides/optimized-baseline.md"
+cp_doc "$WIP/well-lit-paths/precise-prefix-cache-routing.md" "$DOCS_DIR/guides/precise-prefix-cache-routing.md"
+cp_doc "$WIP/well-lit-paths/tiered-prefix-cache.md"         "$DOCS_DIR/guides/tiered-prefix-cache.md"
+cp_doc "$WIP/well-lit-paths/asynchronous-processing.md"     "$DOCS_DIR/guides/asynchronous-processing.md"
+cp_doc "$WIP/well-lit-paths/flow-control.md"                "$DOCS_DIR/guides/flow-control.md"
+cp_doc "$WIP/well-lit-paths/pd-disaggregation.md"           "$DOCS_DIR/guides/pd-disaggregation.md"
+cp_doc "$WIP/well-lit-paths/predicted-latency.md"           "$DOCS_DIR/guides/predicted-latency.md"
+cp_doc "$WIP/well-lit-paths/wide-expert-parallelism.md"     "$DOCS_DIR/guides/wide-expert-parallelism.md"
+cp_doc "$WIP/well-lit-paths/workload-autoscaling.md"        "$DOCS_DIR/guides/workload-autoscaling.md"
+cp_doc "$WIP/well-lit-paths/no-kubernetes-deployment.md"    "$DOCS_DIR/guides/no-kubernetes-deployment.md"
+cp_doc "$WIP/well-lit-paths/experimental/batch-gateway.md"  "$DOCS_DIR/guides/batch-gateway.md"
 
 sed_inplace \
     -e 's|\](optimized-baseline\.md)|\](/guides/optimized-baseline)|g' \
-    -e 's|\](predicted-latency\.md)|\](/guides/predicted-latency-routing)|g' \
+    -e 's|\](predicted-latency\.md)|\](/guides/predicted-latency)|g' \
     -e 's|\](precise-prefix-cache-aware\.md)|\](/guides/precise-prefix-cache-routing)|g' \
     -e 's|\](precise-prefix-cache-routing\.md)|\](/guides/precise-prefix-cache-routing)|g' \
     -e 's|\](tiered-prefix-cache\.md)|\](/guides/tiered-prefix-cache)|g' \
     -e 's|\](pd-disaggregation\.md)|\](/guides/pd-disaggregation)|g' \
-    -e 's|\](wide-expert-parallelism\.md)|\](/guides/wide-ep-lws)|g' \
+    -e 's|\](wide-expert-parallelism\.md)|\](/guides/wide-expert-parallelism)|g' \
     -e 's|\](flow-control\.md)|\](/guides/flow-control)|g' \
     -e 's|\](workload-autoscaling\.md)|\](/guides/workload-autoscaling)|g' \
     -e 's|\](asynchronous-processing\.md)|\](/guides/asynchronous-processing)|g' \
     -e 's|\](experimental/batch-gateway\.md)|\](/guides/batch-gateway)|g' \
     -e 's|\](no-kubernetes-deployment\.md)|\](/guides/no-kubernetes-deployment)|g' \
     "$DOCS_DIR/guides/index.md"
-
-if [[ ! -d "$SRC/guides/predicted-latency-based-scheduling" ]]; then
-    cp_doc "$WIP/well-lit-paths/predicted-latency.md" "$DOCS_DIR/guides/predicted-latency.md"
-fi
 
 # === Resources / Observability ===
 # llm-d/llm-d#1542: docs/resources/observability/ (setup, metrics, tracing, promql).
@@ -222,6 +209,7 @@ cp "$ASSETS"/images/*.png "$STATIC_DIR/" 2>/dev/null || true
 cp_doc "$WIP/resources/rdma/networking-stack.svg" "$STATIC_DIR/" 2>/dev/null || true
 cp_doc "$WIP/architecture/core/images/flow_control_dashboard.png" "$STATIC_DIR/" 2>/dev/null || true
 cp_doc "$WIP/architecture/advanced/autoscaling/hpa-architecture.svg" "$STATIC_DIR/" 2>/dev/null || true
+cp_doc "$WIP/well-lit-paths/no-kubernetes-deployment.svg" "$STATIC_DIR/" 2>/dev/null || true
 
 # Infrastructure Providers images
 echo "    Copying infrastructure provider images..."
@@ -295,7 +283,7 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|advanced/autoscaling/autoscaling\.md|advanced/autoscaling/index.md|g' \
         -e 's|advanced/batch/README\.md|advanced/batch/index.md|g' \
         -e 's|\](/docs/guides/README)|\](/docs/guides)|g' \
-        -e 's|\](/docs/experimental/batch-gateway)|\](/docs/guides/experimental/batch-gateway)|g' \
+        -e 's|\](/docs/experimental/batch-gateway)|\](/guides/batch-gateway)|g' \
         -e 's|\](/docs/architecture/core/epp)|\](/docs/architecture/core/router/epp)|g' \
         -e 's|\](/docs/well-lit-paths/\([^)]*\)\.md)|\](/docs/guides/\1)|g' \
         -e 's|\](well-lit-paths/\([^)]*\))|\](/guides/\1)|g' \
@@ -304,15 +292,20 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](/docs/infra-providers)|\](/docs/resources/infra-providers)|g' \
         -e 's|\](infra-providers/\([^)]*\))|\](/resources/infra-providers/\1)|g' \
         -e 's|\](/docs/\([^)]*\)/README\.md)|\](/docs/\1)|g' \
-        -e 's|\](/docs/guides/predicted-latency-based-scheduling)|\](/docs/guides/predicted-latency-routing)|g' \
-        -e 's|\](/guides/predicted-latency-based-scheduling)|\](/guides/predicted-latency-routing)|g' \
+        -e 's|\](/docs/guides/predicted-latency-based-scheduling)|\](/docs/guides/predicted-latency)|g' \
+        -e 's|\](/guides/predicted-latency-based-scheduling)|\](/guides/predicted-latency)|g' \
+        -e 's|\](/docs/guides/no-kubernetes-deployment)|\](/guides/no-kubernetes-deployment)|g' \
+        -e 's|\](/docs/guides/precise-prefix-cache-routing)|\](/guides/precise-prefix-cache-routing)|g' \
+        -e 's|\](/docs/guides/predicted-latency)|\](/guides/predicted-latency)|g' \
+        -e 's|\](/docs/guides/wide-expert-parallelism)|\](/guides/wide-expert-parallelism)|g' \
+        -e 's|\](/docs/guides/batch-gateway)|\](/guides/batch-gateway)|g' \
         -e 's|llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/profile)|llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/profilehandler)|g' \
-        -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-routing)|g' \
-        -e 's|\](/guides/predicted-latency)|\](/guides/predicted-latency-routing)|g' \
-        -e 's|\](../../guides/predicted-latency)|\](/guides/predicted-latency-routing)|g' \
-        -e 's|\](/docs/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
-        -e 's|\](/guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \
-        -e 's|\](../../guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \
+        -e 's|\](/docs/guides/predicted-latency-routing)|\](/docs/guides/predicted-latency)|g' \
+        -e 's|\](/guides/predicted-latency-routing)|\](/guides/predicted-latency)|g' \
+        -e 's|\](../../guides/predicted-latency-routing)|\](/guides/predicted-latency)|g' \
+        -e 's|\](/docs/guides/wide-ep-lws)|\](/docs/guides/wide-expert-parallelism)|g' \
+        -e 's|\](/guides/wide-ep-lws)|\](/guides/wide-expert-parallelism)|g' \
+        -e 's|\](../../guides/wide-ep-lws)|\](/guides/wide-expert-parallelism)|g' \
         -e 's|\](../../../../guides/tiered-prefix-cache)|\](/guides/tiered-prefix-cache)|g' \
         -e 's|\](/guides/tiered-prefix-cache)|\](/guides/tiered-prefix-cache)|g' \
         -e 's|\](../../../../guides/batch-gateway)|\](/guides/batch-gateway)|g' \
@@ -320,6 +313,10 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](../../../guides/batch-gateway)|\](/guides/batch-gateway)|g' \
         -e 's|\](../../../guides/asynchronous-processing)|\](/guides/asynchronous-processing)|g' \
         -e 's|\](../../guides/pd-disaggregation/README\.md)|\](/guides/pd-disaggregation)|g' \
+        -e 's|\](../../guides/no-kubernetes-deployment)|\](/guides/no-kubernetes-deployment)|g' \
+        -e 's|\](../../guides/precise-prefix-cache-routing)|\](/guides/precise-prefix-cache-routing)|g' \
+        -e 's|\](../../getting-started/quickstart\.md)|\](/getting-started/quickstart)|g' \
+        -e 's|\](../../architecture/advanced/batch/batch-gateway\.md)|\](/architecture/advanced/batch/batch-gateway)|g' \
         "$file"
 done
 
@@ -503,7 +500,7 @@ fi
 if [[ -f "$DOCS_DIR/resources/rdma/rdma-configuration.md" ]]; then
     sed_inplace \
         -e 's|\](../../well-lit-paths/pd-disaggregation\.md)|\](/guides/pd-disaggregation)|g' \
-        -e 's|\](../../well-lit-paths/wide-expert-parallelism\.md)|\](/guides/wide-ep-lws)|g' \
+        -e 's|\](../../well-lit-paths/wide-expert-parallelism\.md)|\](/guides/wide-expert-parallelism)|g' \
         -e 's|\](../../architecture/core/model-servers\.md)|\](/architecture/core/model-servers)|g' \
         "$DOCS_DIR/resources/rdma/rdma-configuration.md"
 fi

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -26,6 +26,7 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 DOCS_DIR="$PROJECT_DIR/docs"
 GUIDES_DIR="$PROJECT_DIR/guides"
 STATIC_DIR="$PROJECT_DIR/static/img/docs"
+UPSTREAM_REF="$BRANCH"
 
 echo "==> Syncing docs from llm-d/llm-d @ $BRANCH"
 
@@ -290,6 +291,9 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](/docs/infra-providers)|\](/docs/resources/infra-providers)|g' \
         -e 's|\](infra-providers/\([^)]*\))|\](/resources/infra-providers/\1)|g' \
         -e 's|\](/docs/\([^)]*\)/README\.md)|\](/docs/\1)|g' \
+        -e 's|\](../../getting-started/quickstart\.md)|\](/getting-started/quickstart)|g' \
+        -e 's|\](../../architecture/advanced/batch/batch-gateway\.md)|\](/architecture/advanced/batch/batch-gateway)|g' \
+        -e 's|llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/profile)|llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/profilehandler)|g' \
         -e 's|\](../../guides/optimized-baseline)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline)|g' \
         -e 's|\](../../guides/precise-prefix-cache-routing)|\](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-routing)|g' \
         -e 's|\](../../guides/tiered-prefix-cache)|\](https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache)|g' \
@@ -567,6 +571,17 @@ done
 echo "    Fixing /img/docs/images/ paths..."
 find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
     sed_inplace 's|/img/docs/images/|/img/docs/|g' "$file"
+done
+
+# === Rewrite upstream repo links to the synced branch ===
+# Keeps dev docs pointing to main while making release docs point to their
+# matching upstream release branch.
+echo "    Repointing llm-d upstream links to $UPSTREAM_REF..."
+find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
+    sed_inplace \
+        -e "s|https://github.com/llm-d/llm-d/tree/main/|https://github.com/llm-d/llm-d/tree/$UPSTREAM_REF/|g" \
+        -e "s|https://github.com/llm-d/llm-d/blob/main/|https://github.com/llm-d/llm-d/blob/$UPSTREAM_REF/|g" \
+        "$file"
 done
 
 # === Generate stubs for pages in outline that don't have source content yet ===

--- a/preview/scripts/test-fixtures/transformation-test.expected.md
+++ b/preview/scripts/test-fixtures/transformation-test.expected.md
@@ -135,15 +135,15 @@ A link already in markdown format should be unchanged: [llm-d](https://github.co
 Images with unquoted attributes should be quoted for MDX:
 
 <p align="center">
-  <img alt="Test" src="/docs/img/docs/test.svg" width="95%" />
+  <img alt="Test" src="/img/docs/test.svg" width="95%" />
 </p>
 
-<img src="/docs/img/docs/another.png" height="200" />
+<img src="/img/docs/another.png" height="200" />
 
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" />
-    <img alt="Test Arch" src="/docs/img/docs/arch.svg" width="90%" />
+    <img alt="Test Arch" src="/img/docs/arch.svg" width="90%" />
   </picture>
 </p>
 

--- a/preview/scripts/transformations.sh
+++ b/preview/scripts/transformations.sh
@@ -18,24 +18,23 @@ fi
 apply_transformations() {
     local file="$1"
 
-    # Image paths - convert relative to absolute
-    # Different handling for markdown vs HTML:
-    # - Markdown images: Use /img/docs/ (Docusaurus auto-prepends baseUrl)
-    # - HTML img/source tags: Use /docs/img/docs/ (raw HTML needs full path with baseUrl)
+    # Image paths - convert relative to absolute.
+    # Use /img/docs/ for both markdown and HTML so links work under /docs/, /docs/dev/,
+    # and versioned docs paths.
 
     # Transform markdown image syntax: ![alt](../assets/...) -> ![alt](/img/docs/...)
     sed_inplace \
         -e 's|!\[\([^]]*\)\](\(\.\./\)*assets/\([^)]*\))|![\1](/img/docs/\3)|g' \
         "$file"
 
-    # Transform HTML img tag src: src="../assets/..." -> src="/docs/img/docs/..."
+    # Transform HTML img tag src: src="../assets/..." -> src="/img/docs/..."
     sed_inplace \
-        -e 's|src="\(\.\./\)*assets/\([^"]*\)"|src="/docs/img/docs/\2"|g' \
+        -e 's|src="\(\.\./\)*assets/\([^"]*\)"|src="/img/docs/\2"|g' \
         "$file"
 
-    # Transform HTML source tag srcset: srcset="../assets/..." -> srcset="/docs/img/docs/..."
+    # Transform HTML source tag srcset: srcset="../assets/..." -> srcset="/img/docs/..."
     sed_inplace \
-        -e 's|srcset="\(\.\./\)*assets/\([^"]*\)"|srcset="/docs/img/docs/\2"|g' \
+        -e 's|srcset="\(\.\./\)*assets/\([^"]*\)"|srcset="/img/docs/\2"|g' \
         "$file"
 
     # MDX escaping - escape special characters
@@ -109,14 +108,14 @@ apply_transformations() {
         -e 's|\](./storage/README\.md)|\](./storage/index.md)|g' \
         "$file"
 
-    # Fix guide name variations and relative paths
+    # Normalize guide slug variations to well-lit-path canonical paths.
     sed_inplace \
-        -e 's|\](/docs/guides/predicted-latency)|\](/docs/guides/predicted-latency-routing)|g' \
-        -e 's|\](/guides/predicted-latency)|\](/guides/predicted-latency-routing)|g' \
-        -e 's|\](../../guides/predicted-latency)|\](/guides/predicted-latency-routing)|g' \
-        -e 's|\](/docs/guides/wide-expert-parallelism)|\](/docs/guides/wide-ep-lws)|g' \
-        -e 's|\](/guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \
-        -e 's|\](../../guides/wide-expert-parallelism)|\](/guides/wide-ep-lws)|g' \
+        -e 's|\](/docs/guides/predicted-latency-routing)|\](/docs/guides/predicted-latency)|g' \
+        -e 's|\](/guides/predicted-latency-routing)|\](/guides/predicted-latency)|g' \
+        -e 's|\](../../guides/predicted-latency-routing)|\](/guides/predicted-latency)|g' \
+        -e 's|\](/docs/guides/wide-ep-lws)|\](/docs/guides/wide-expert-parallelism)|g' \
+        -e 's|\](/guides/wide-ep-lws)|\](/guides/wide-expert-parallelism)|g' \
+        -e 's|\](../../guides/wide-ep-lws)|\](/guides/wide-expert-parallelism)|g' \
         -e 's|\](../../prereq/gateway-provider/common-configurations/*)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider#common-configurations)|g' \
         -e 's|\](../gateway/*)|\](/guides/recipes/gateway)|g' \
         "$file"

--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -100,95 +100,23 @@ const sidebars: SidebarsConfig = {
         },
       ],
     },
-    // ==================== Guides ====================
+    // ==================== Well-Lit Paths ====================
     {
       type: 'category',
-      label: 'Guides',
+      label: 'Well-Lit Paths',
       collapsed: false,
       link: {type: 'doc', id: 'guides/index'},
       items: [
-        {
-          type: 'category',
-          label: 'Optimized Baseline',
-          link: {type: 'doc', id: 'guides/optimized-baseline/index'},
-          items: [],
-        },
-        {
-          type: 'category',
-          label: 'Precise Prefix Cache Routing',
-          link: {type: 'doc', id: 'guides/precise-prefix-cache-routing/index'},
-          items: [],
-        },
-        {
-          type: 'category',
-          label: 'Tiered Prefix Cache',
-          link: {type: 'doc', id: 'guides/tiered-prefix-cache/index'},
-          items: [
-            'guides/tiered-prefix-cache/cpu/index',
-            {
-              type: 'category',
-              label: 'Storage Offloading',
-              link: {type: 'doc', id: 'guides/tiered-prefix-cache/storage/index'},
-              items: [
-                'guides/tiered-prefix-cache/storage/manifests/backends/lustre/index',
-                'guides/tiered-prefix-cache/storage/manifests/backends/aws/index',
-              ],
-            },
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Asynchronous Processing',
-          link: {type: 'doc', id: 'guides/asynchronous-processing/index'},
-          items: [
-            'guides/asynchronous-processing/gcp-pubsub/index',
-            'guides/asynchronous-processing/redis/index',
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Flow Control',
-          link: {type: 'doc', id: 'guides/flow-control/index'},
-          items: [],
-        },
-        {
-          type: 'category',
-          label: 'Prefill/Decode Disaggregation',
-          link: {type: 'doc', id: 'guides/pd-disaggregation/index'},
-          items: [],
-        },
-        'guides/predicted-latency-routing/index',
-        {
-          type: 'category',
-          label: 'Wide Expert Parallelism',
-          link: {type: 'doc', id: 'guides/wide-ep-lws/index'},
-          items: [
-            {
-              type: 'category',
-              label: 'Experimental DP-Aware',
-              link: {type: 'doc', id: 'guides/wide-ep-lws/experimental-dp-aware/index'},
-              items: [
-                'guides/wide-ep-lws/experimental-dp-aware/benchmarks/index',
-              ],
-            },
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Workload Autoscaling',
-          link: {type: 'doc', id: 'guides/workload-autoscaling/index'},
-          items: [],
-        },
-        'guides/batch-gateway/index',
-        {
-          type: 'category',
-          label: 'Recipes',
-          items: [
-            'guides/recipes/gateway/index',
-            'guides/recipes/router/index',
-            'guides/recipes/modelserver/components/disable-gke-nccl-tuner-patch/index',
-          ],
-        },
+        'guides/optimized-baseline',
+        'guides/precise-prefix-cache-routing',
+        'guides/tiered-prefix-cache',
+        'guides/asynchronous-processing',
+        'guides/flow-control',
+        'guides/pd-disaggregation',
+        'guides/predicted-latency',
+        'guides/wide-expert-parallelism',
+        'guides/workload-autoscaling',
+        'guides/no-kubernetes-deployment',
       ],
     },
     // ==================== Resources ====================

--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -116,6 +116,7 @@ const sidebars: SidebarsConfig = {
         'guides/predicted-latency',
         'guides/wide-expert-parallelism',
         'guides/workload-autoscaling',
+        'guides/batch-gateway',
         'guides/no-kubernetes-deployment',
       ],
     },


### PR DESCRIPTION
## What does this PR do?

- Restored dev docs to the intended Well-Lit Paths model (reverting the PR #292 behavior that surfaced detailed guides/* content directly in nav).
- Renamed the top-level docs section from Guides to Well-Lit Paths and aligned sidebar entries to the high-level well-lit-path pages.
- Updated source/edit URL mapping so guide pages on dev point to upstream llm-d/llm-d docs/well-lit-paths (with legacy slug compatibility).
- Refactored docs sync to copy well-lit-path overview pages (plus experimental Batch Gateway) and added compatibility rewrites so old/renamed guide links continue to resolve.
- Added targeted link normalizations for /docs/dev pathing issues (relative .md links, legacy slugs, and internal cross-links) and copied missing no-kubernetes SVG asset.
- Normalized transformed image URLs to /img/docs/... (baseUrl-safe across /docs, /docs/dev, and versioned docs) and updated transformation test fixtures accordingly.

## How was this tested?

- [x] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build:all`)
- [x] Check links (`npm run check-links`)
- [x] Manual testing performed (`npm run serve`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build:all`)
- [x] Check links (`npm run check-links`)

## Related Issues

Fixes #321 
