### PR TITLE
Fixes missing footer logo and updates policies

### DIFF
--- a/preview/docusaurus.config.ts
+++ b/preview/docusaurus.config.ts
@@ -270,7 +270,20 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} llm-d project. Apache 2.0 License.`,
+      copyright: `Copyright © ${new Date().getFullYear()} llm-d project. Apache 2.0 License.<br />\
+        We are a Cloud Native Computing Foundation sandbox project.<br />\
+        For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/" target="_blank" rel="noreferrer noopener">https://lfprojects.org/policies/</a>`,
+      logo: {
+        alt: "llm-d Logo",
+        src: "img/cncf-white.png",
+        href: "https://cncf.io",
+        target: "_blank",
+        width: 240,
+        className: "footer-logo",
+        style: {
+          marginRight: "10px",
+        },
+      },
     },
     prism: {
       theme: prismThemes.github,


### PR DESCRIPTION
## What does this PR do?

Integrates the Cloud Native Computing Foundation (CNCF) logo into the website footer.
Expands the footer's copyright text to include a declaration of the project's CNCF sandbox status and a direct link to LF Projects' policies page.

## Why is this change needed?

Addresses a bug where the CNCF logo was absent from the site's footer, ensuring proper branding and visibility across all pages. It also provides important legal and project governance information directly within the footer, making it easily accessible to users.

## How was this tested?

- [x] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build:all`)
- [x] Check links after buildling (`npm run check-links`)
- [x] Manual testing performed (`npm run serve`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build:all`)
- [x] No broken links after building full site (`npm run check-links`)
- [ ] Documentation updated (if applicable)

## Related Issues
Issue: #351
PR #352