### PR TITLE
fix: update gateway editUrl to point to docs/resources/gateway/

### DIFF
--- a/preview/docusaurus.config.ts
+++ b/preview/docusaurus.config.ts
@@ -140,10 +140,9 @@ const config: Config = {
               return `https://github.com/llm-d/llm-d/blob/main/${wellLitPath}`;
             }
 
-            // Gateway pages come from guides/prereq/gateways/ in the upstream repo
+            // Gateway pages come from docs/resources/gateway/ in the upstream repo
             if (cleanPath.startsWith('resources/gateway/')) {
-              const gatewayFile = sourcePath.replace(/^resources\/gateway\//, '');
-              return `https://github.com/llm-d/llm-d/blob/main/guides/prereq/gateways/${gatewayFile}`;
+              return `https://github.com/llm-d/llm-d/blob/main/docs/resources/gateway/${sourcePath.replace(/^resources\/gateway\//, '')}`;
             }
 
             // Infra-provider pages come from docs/infra-providers/ (not docs/resources/infra-providers/)


### PR DESCRIPTION
## Summary
- The gateway docs moved from `guides/prereq/gateways/` to `docs/resources/gateway/` in the upstream `llm-d/llm-d` repo
- The `editUrl` function in `preview/docusaurus.config.ts` was still generating "Edit this page" links to the old path, producing 13 broken GitHub URLs that fail the link checker CI
- This blocks all PRs (e.g. #326) from passing the "Test deployment" check

## Test plan
- [ ] Verify "Test deployment" CI check passes (broken GitHub URL count should drop by 13)
- [ ] Verify gateway pages' "Edit this page" links point to the correct upstream files

Signed-off-by: Carlos H. Andrade Costa <carlos.andrade.costa@gmail.com>