### PR TITLE
fix: update sync-docs.sh to copy gateway docs from new location

### DIFF
--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -263,11 +263,12 @@ else
     cp_doc "$WIP/guides/monitoring/tracing.md"                "$DOCS_DIR/resources/observability/tracing.md"
 fi
 
-# PR llm-d/llm-d#1259 moved gateway docs to guides/prereq/gateways/
-cp_doc "$SRC/guides/prereq/gateways/README.md"              "$DOCS_DIR/resources/gateway/index.md"
-cp_doc "$SRC/guides/prereq/gateways/istio.md"               "$DOCS_DIR/resources/gateway/istio.md"
-cp_doc "$SRC/guides/prereq/gateways/gke.md"                 "$DOCS_DIR/resources/gateway/gke.md"
-cp_doc "$SRC/guides/prereq/gateways/agentgateway.md"        "$DOCS_DIR/resources/gateway/agentgateway.md"
+# Gateway docs now live under docs/resources/gateway/
+cp_doc "$WIP/resources/gateway/README.md"                    "$DOCS_DIR/resources/gateway/index.md"
+cp_doc "$WIP/resources/gateway/istio.md"                     "$DOCS_DIR/resources/gateway/istio.md"
+cp_doc "$WIP/resources/gateway/gke.md"                       "$DOCS_DIR/resources/gateway/gke.md"
+cp_doc "$WIP/resources/gateway/agentgateway.md"              "$DOCS_DIR/resources/gateway/agentgateway.md"
+cp_doc "$WIP/resources/gateway/install-crds.md"              "$DOCS_DIR/resources/gateway/install-crds.md"
 
 cp_doc "$WIP/resources/rdma/README.md"                      "$DOCS_DIR/resources/rdma/rdma-configuration.md"
 
@@ -370,7 +371,12 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|core/epp/README\.md|core/epp/index.md|g' \
         -e 's|advanced/autoscaling/README\.md|advanced/autoscaling/index.md|g' \
         -e 's|advanced/disaggregation/README\.md|advanced/disaggregation/index.md|g' \
+        -e 's|resources/gateway/README\.md|resources/gateway/index.md|g' \
         -e 's|resources/gateways/README\.md|../resources/gateway/index.md|g' \
+        -e 's|\](.*guides/prereq/gateways/README\.md)|\](/resources/gateway)|g' \
+        -e 's|\](.*guides/prereq/gateways/istio\.md)|\](/resources/gateway/istio)|g' \
+        -e 's|\](.*guides/prereq/gateways/gke\.md)|\](/resources/gateway/gke)|g' \
+        -e 's|\](.*guides/prereq/gateways/agentgateway\.md)|\](/resources/gateway/agentgateway)|g' \
         -e 's|guides/README\.md|guides/index.md|g' \
         -e 's|architecture/introduction\.md|architecture/index.md|g' \
         -e 's|architecture/README\.md|architecture/index.md|g' \
@@ -481,9 +487,9 @@ done
 echo "    Fixing prereq and helper file references..."
 find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
     sed_inplace \
-        -e 's|\](../prereq/gateways)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateways)|g' \
-        -e 's|\](../../prereq/gateways)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateways)|g' \
-        -e 's|\](/docs/prereq/gateways)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateways)|g' \
+        -e 's|\](../prereq/gateways)|\](/resources/gateway)|g' \
+        -e 's|\](../../prereq/gateways)|\](/resources/gateway)|g' \
+        -e 's|\](/docs/prereq/gateways)|\](/resources/gateway)|g' \
         -e 's|\](/docs/guides/prereq/gateway-provider)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider)|g' \
         -e 's|\](../../prereq/gateway-provider/README\.md#supported-providers)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider#supported-providers)|g' \
         -e 's|\](../../prereq/gateway-provider/common-configurations)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateway-provider#common-configurations)|g' \
@@ -551,8 +557,8 @@ find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](./router/epp/config\.yaml)|\](https://github.com/llm-d/llm-d/blob/main/guides/no-kubernetes-deployment/router/epp/config.yaml)|g' \
         -e 's|\](./router/epp/endpoints\.yaml)|\](https://github.com/llm-d/llm-d/blob/main/guides/no-kubernetes-deployment/router/epp/endpoints.yaml)|g' \
         -e 's|\](./router/envoy/envoy\.yaml)|\](https://github.com/llm-d/llm-d/blob/main/guides/no-kubernetes-deployment/router/envoy/envoy.yaml)|g' \
-        -e 's|\](../../04_customizing_a_guide\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateways)|g' \
-        -e 's|\](/docs/04_customizing_a_guide\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/prereq/gateways)|g' \
+        -e 's|\](../../04_customizing_a_guide\.md)|\](/resources/gateway)|g' \
+        -e 's|\](/docs/04_customizing_a_guide\.md)|\](/resources/gateway)|g' \
         -e 's|\](../../02_verifying_a_guide\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline)|g' \
         -e 's|\](/docs/02_verifying_a_guide\.md)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline)|g' \
         -e 's|\](../../02_verifying_a_guide\.md#following-logs-for-requests)|\](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline)|g' \
@@ -582,7 +588,7 @@ find "$DOCS_DIR/guides" -name "*.md" -print0 | while IFS= read -r -d '' file; do
 done
 
 # === Fix gateway index.md links ===
-# gateway/index.md comes from guides/prereq/gateways/README.md — fix relative paths
+# gateway/index.md comes from docs/resources/gateway/README.md — fix relative paths
 if [[ -f "$DOCS_DIR/resources/gateway/index.md" ]]; then
     sed_inplace \
         -e 's|\](../../guides/README\.md)|\](/guides)|g' \
@@ -736,6 +742,7 @@ generate_stub "$DOCS_DIR/resources/gateway/index.md" "Gateway" "Gateway deployme
 generate_stub "$DOCS_DIR/resources/gateway/istio.md" "Istio" "Deploying llm-d with Istio gateway"
 generate_stub "$DOCS_DIR/resources/gateway/gke.md" "GKE" "Deploying llm-d with GKE gateway"
 generate_stub "$DOCS_DIR/resources/gateway/agentgateway.md" "Agent Gateway" "Deploying llm-d with Agent Gateway"
+generate_stub "$DOCS_DIR/resources/gateway/install-crds.md" "Install CRDs" "Installing Gateway API CRDs"
 generate_stub "$DOCS_DIR/architecture/advanced/batch/index.md" "Batch Processing" "Asynchronous batch inference architecture"
 generate_stub "$DOCS_DIR/architecture/advanced/batch/batch-gateway.md" "Batch Gateway" "Gateway for batch inference requests"
 generate_stub "$DOCS_DIR/architecture/advanced/batch/async-processor.md" "Async Processor" "Asynchronous request processing component"


### PR DESCRIPTION
## Summary
Follow-up to #366. The gateway docs moved from `guides/prereq/gateways/` to `docs/resources/gateway/` in `llm-d/llm-d`.

Changes to `sync-docs.sh`:
- Copy gateway files from `docs/resources/gateway/` instead of `guides/prereq/gateways/`
- Add `install-crds.md` to the sync (new upstream file referenced by gateway docs)
- Add sed rules to rewrite `guides/prereq/gateways/` links in architecture docs to absolute site paths
- Fix `README.md` → `index.md` resolution for gateway links in the dev build
- Rewrite `prereq/gateways` sed replacements in guides to use internal site paths

Also pushed a direct fix to the `release-0.7.0` branch to replace the baked-in broken GitHub URLs in the proxy page snapshot (4 absolute `guides/prereq/gateways/` URLs → internal site paths).
