### PR TITLE
fix: update broken guide link in KV cache offloading blog

### DIFF
--- a/blog/2026-02-09_native-kv-cache-offloading-to-any-file-system-with-llm-d.md
+++ b/blog/2026-02-09_native-kv-cache-offloading-to-any-file-system-with-llm-d.md
@@ -59,7 +59,7 @@ In addition, the following performance-related design choices were made:
 
 Using the FS offloading connector is simple, requires a `pip install`, and a directory path to the storage being used. Other optional tunable parameters are the storage block size (in tokens) and the number of worker threads. 
 
-Detailed instructions can be found in the llm-d well-lit path [guide](/docs/dev/well-lit-paths/tiered-prefix-cache).
+Detailed instructions can be found in the llm-d well-lit path [guide](/docs/guides/tiered-prefix-cache).
 
 Note that while the results presented in this blog were of tests run with IBM Storage Scale, the connector was also tested with other storage options including local storage (NVMe drive with a filesystem mounted on it) and CephFS. In general it will work seamlessly with any storage supporting a filesystem API or that has a filesystem mounted on it.
 


### PR DESCRIPTION
## Summary
- `/docs/dev/well-lit-paths/tiered-prefix-cache` no longer exists after the docs reorganization
- Updated to `/docs/guides/tiered-prefix-cache`

## Test plan
- [ ] Verify the link resolves correctly at https://llm-d.ai/docs/guides/tiered-prefix-cache