### PR TITLE
fix(sidebar): collapse all left-nav categories by default

### DIFF
--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -7,7 +7,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Getting Started',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'getting-started/index'},
       items: [
         'getting-started/quickstart',
@@ -24,7 +24,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Core',
-          collapsed: false,
+          collapsed: true,
           items: [
             'architecture/core/inferencepool',
             {
@@ -53,12 +53,12 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Advanced',
-          collapsed: false,
+          collapsed: true,
           items: [
             {
               type: 'category',
               label: 'Disaggregation',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/disaggregation/index'},
               items: [
                 'architecture/advanced/disaggregation/operations-vllm',
@@ -68,7 +68,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'KV Cache Management',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/kv-management/index'},
               items: [
                 'architecture/advanced/kv-management/prefix-cache-aware-routing',
@@ -79,7 +79,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'Autoscaling',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/autoscaling/index'},
               items: [
                 'architecture/advanced/autoscaling/workload-variant-autoscaling',
@@ -89,7 +89,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'Batch Processing',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/batch/index'},
               items: [
                 'architecture/advanced/batch/batch-gateway',
@@ -104,7 +104,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Well-Lit Paths',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'guides/index'},
       items: [
         'guides/optimized-baseline',
@@ -135,7 +135,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Gateway',
-          collapsed: false,
+          collapsed: true,
           link: {type: 'doc', id: 'resources/gateway/index'},
           items: [
             'resources/gateway/istio',
@@ -146,7 +146,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Infrastructure Providers',
-          collapsed: false,
+          collapsed: true,
           link: {type: 'doc', id: 'resources/infra-providers/index'},
           items: [
             'resources/infra-providers/aks',
@@ -160,7 +160,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Observability',
-          collapsed: false,
+          collapsed: true,
           link: {type: 'doc', id: 'resources/observability/index'},
           items: [
             'resources/observability/setup',


### PR DESCRIPTION
Replaces every `collapsed: false` in `preview/sidebars.ts` with `collapsed: true` so visitors don't see every top-level and nested category expanded on first load. Docusaurus still auto-expands the category containing the current page, so users can still see where they are.

**Affects `/docs/dev/*`** (dev docs from `llm-d/llm-d@main`).

A companion PR will backport the same edit to `release-0.7.0` so `/docs/` and `/docs/0.7.0/` get the same UX without waiting for the next release tag.