### PR TITLE
fix(sidebar): collapse all left-nav categories by default (release-0.7.0 backport)

### DIFF
--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -7,7 +7,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Getting Started',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'getting-started/index'},
       items: [
         'getting-started/quickstart',
@@ -24,7 +24,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Core',
-          collapsed: false,
+          collapsed: true,
           items: [
             'architecture/core/inferencepool',
             {
@@ -53,12 +53,12 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Advanced',
-          collapsed: false,
+          collapsed: true,
           items: [
             {
               type: 'category',
               label: 'Disaggregation',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/disaggregation/index'},
               items: [
                 'architecture/advanced/disaggregation/operations-vllm',
@@ -68,7 +68,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'KV Cache Management',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/kv-management/index'},
               items: [
                 'architecture/advanced/kv-management/prefix-cache-aware-routing',
@@ -79,7 +79,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'Autoscaling',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/autoscaling/index'},
               items: [
                 'architecture/advanced/autoscaling/workload-variant-autoscaling',
@@ -89,7 +89,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'Batch Processing',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/batch/index'},
               items: [
                 'architecture/advanced/batch/batch-gateway',
@@ -104,7 +104,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Guides',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'guides/index'},
       items: [
         'guides/optimized-baseline',
@@ -127,7 +127,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Gateway',
-          collapsed: false,
+          collapsed: true,
           link: {type: 'doc', id: 'resources/gateway/index'},
           items: [
             'resources/gateway/istio',
@@ -138,7 +138,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Infrastructure Providers',
-          collapsed: false,
+          collapsed: true,
           link: {type: 'doc', id: 'resources/infra-providers/index'},
           items: [
             'resources/infra-providers/aks',
@@ -152,7 +152,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Monitoring',
-          collapsed: false,
+          collapsed: true,
           items: [
             'resources/monitoring/metrics',
             'resources/monitoring/tracing',


### PR DESCRIPTION
Backport of #372 to `release-0.7.0` so the same collapsed-by-default UX applies to `/docs/` and `/docs/0.7.0/` (which serve from this branch), not just `/docs/dev/`.

Replaces every `collapsed: false` in `preview/sidebars.ts` with `collapsed: true`. Docusaurus still auto-expands the category containing the current page, so users can still see where they are.

**Pairs with** #372 (same change on `main`).