### PR TITLE
fix(sidebar): collapse, rename, reorder, and restyle v0.7.0 left nav

### DIFF
--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -7,17 +7,35 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Getting Started',
-      collapsed: true,
+      collapsed: false,
       link: {type: 'doc', id: 'getting-started/index'},
       items: [
         'getting-started/quickstart',
         'getting-started/artifacts',
       ],
     },
-    // ==================== Architecture ====================
+    // ==================== Well-Lit Paths ====================
     {
       type: 'category',
-      label: 'Architecture',
+      label: 'Well-Lit Paths',
+      collapsed: false,
+      link: {type: 'doc', id: 'guides/index'},
+      items: [
+        'guides/optimized-baseline',
+        'guides/precise-prefix-cache-aware',
+        'guides/tiered-prefix-cache',
+        'guides/asynchronous-processing',
+        'guides/flow-control',
+        'guides/pd-disaggregation',
+        'guides/predicted-latency',
+        'guides/wide-expert-parallelism',
+        'guides/workload-autoscaling',
+      ],
+    },
+    // ==================== Concepts (Architecture) ====================
+    {
+      type: 'category',
+      label: 'Concepts (Architecture)',
       collapsed: true,
       link: {type: 'doc', id: 'architecture/index'},
       items: [
@@ -98,24 +116,6 @@ const sidebars: SidebarsConfig = {
             },
           ],
         },
-      ],
-    },
-    // ==================== Guides ====================
-    {
-      type: 'category',
-      label: 'Guides',
-      collapsed: true,
-      link: {type: 'doc', id: 'guides/index'},
-      items: [
-        'guides/optimized-baseline',
-        'guides/precise-prefix-cache-aware',
-        'guides/tiered-prefix-cache',
-        'guides/asynchronous-processing',
-        'guides/flow-control',
-        'guides/pd-disaggregation',
-        'guides/predicted-latency',
-        'guides/wide-expert-parallelism',
-        'guides/workload-autoscaling',
       ],
     },
     // ==================== Resources ====================

--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -7,7 +7,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Getting Started',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'getting-started/index'},
       items: [
         'getting-started/quickstart',
@@ -24,7 +24,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Core',
-          collapsed: false,
+          collapsed: true,
           items: [
             'architecture/core/inferencepool',
             {
@@ -53,12 +53,12 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Advanced',
-          collapsed: false,
+          collapsed: true,
           items: [
             {
               type: 'category',
               label: 'Disaggregation',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/disaggregation/index'},
               items: [
                 'architecture/advanced/disaggregation/operations-vllm',
@@ -68,7 +68,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'KV Cache Management',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/kv-management/index'},
               items: [
                 'architecture/advanced/kv-management/prefix-cache-aware-routing',
@@ -79,7 +79,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'Autoscaling',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/autoscaling/index'},
               items: [
                 'architecture/advanced/autoscaling/workload-variant-autoscaling',
@@ -89,7 +89,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'Batch Processing',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/batch/index'},
               items: [
                 'architecture/advanced/batch/batch-gateway',
@@ -104,7 +104,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Guides',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'guides/index'},
       items: [
         'guides/optimized-baseline',
@@ -127,7 +127,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Gateway',
-          collapsed: false,
+          collapsed: true,
           link: {type: 'doc', id: 'resources/gateway/index'},
           items: [
             'resources/gateway/istio',
@@ -138,7 +138,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Infrastructure Providers',
-          collapsed: false,
+          collapsed: true,
           link: {type: 'doc', id: 'resources/infra-providers/index'},
           items: [
             'resources/infra-providers/aks',
@@ -152,7 +152,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Monitoring',
-          collapsed: false,
+          collapsed: true,
           items: [
             'resources/monitoring/metrics',
             'resources/monitoring/tracing',

--- a/preview/src/css/custom.css
+++ b/preview/src/css/custom.css
@@ -346,3 +346,47 @@ table th {
 .theme-doc-version-banner {
   border-radius: 6px;
 }
+
+/* ============================================
+   Sidebar visual hierarchy
+   ============================================ */
+
+/* All sidebar items: 14px */
+.menu__link {
+  font-size: 0.875rem;
+}
+
+/* Top-level categories AND standalone top-level doc links (the main sections): semi-bold */
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link,
+.theme-doc-sidebar-item-link-level-1 > .menu__link {
+  font-weight: 600;
+}
+
+/* Sub-categories (pages with sub-pages) and nested leaf doc links: normal weight */
+.theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible > .menu__link,
+.theme-doc-sidebar-item-category-level-3 > .menu__list-item-collapsible > .menu__link,
+.theme-doc-sidebar-item-category-level-4 > .menu__list-item-collapsible > .menu__link,
+.theme-doc-sidebar-item-link-level-2 > .menu__link,
+.theme-doc-sidebar-item-link-level-3 > .menu__link,
+.theme-doc-sidebar-item-link-level-4 > .menu__link,
+.theme-doc-sidebar-item-link-level-5 > .menu__link {
+  font-weight: 400;
+}
+
+/* +4px extra spacing between items inside the sidebar */
+.theme-doc-sidebar-menu .menu__list-item {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+/* 24px breathing room between top-level sidebar sections (overrides the +4px above) */
+.theme-doc-sidebar-menu > .menu__list-item:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+
+/* +8px extra space above sub-category headers (not the first sibling) so
+   adjacent expanded sub-sections aren't visually crammed together. */
+.theme-doc-sidebar-item-category-level-2:not(:first-child),
+.theme-doc-sidebar-item-category-level-3:not(:first-child) {
+  margin-top: 8px;
+}


### PR DESCRIPTION
## Summary

Brings the v0.7.0 stable docs sidebar in line with the dev nav direction. Two commits:

1. **`f8dc81b` — Collapse all left-nav categories by default.** Docusaurus still auto-expands the category containing the current page, so navigation context is preserved.
2. **`f24f5dc` — Apply dev styling and structure to v0.7.0:**
   - Rename `Architecture` → `Concepts (Architecture)`
   - Rename `Guides` → `Well-Lit Paths`
   - Move `Well-Lit Paths` above `Concepts (Architecture)`
   - Expand `Getting Started` and `Well-Lit Paths` by default
   - Sidebar visual hierarchy: 14px items, semibold top-level categories, normal-weight sub-categories and leaf links, +4px between items, 24px between top-level sections, +8px above non-first sub-categories

CSS block is appended to `preview/src/css/custom.css` and mirrors the same block landing on `main` for dev.

## Test plan

- [x] `LLMD_REPO=/tmp/llm-d-work npm run build:all` succeeds; `/docs/0.7.0/getting-started` renders new sidebar
- [x] `/docs/dev/` still renders dev work (verified locally that this branch's CSS matches dev's)
- [ ] Reviewer to spot-check sidebar against `/docs/0.7.0/` after deploy preview

## Notes

This PR replaces closed #373 (which only had the collapse commit) and adds the rename/reorder/expand/CSS block on top.

## Related Issues
#368 
