### PR TITLE
feat(docs): restructure dev left nav and add sidebar visual hierarchy

### DIFF
--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -787,6 +787,11 @@ generate_stub "$DOCS_DIR/architecture/advanced/kv-management/index.md" "KV Cache
 generate_stub "$DOCS_DIR/architecture/advanced/kv-management/prefix-cache-aware-routing.md" "Prefix Cache Aware Routing" "Routing requests to maximize KV cache hits"
 generate_stub "$DOCS_DIR/architecture/advanced/kv-management/kv-indexer.md" "KV-Cache Indexer" "Globally consistent KV cache block tracking"
 generate_stub "$DOCS_DIR/architecture/advanced/kv-management/kv-offloader.md" "KV Offloader" "Tiered KV cache storage hierarchy"
+# Autoscaling sub-pages — upstream main currently ships only the README; stub
+# the sub-pages referenced by the sidebar until wva.md / hpa-keda.md land in
+# llm-d/llm-d. Self-heals once the cp_doc lines above produce real content.
+generate_stub "$DOCS_DIR/architecture/advanced/autoscaling/workload-variant-autoscaling.md" "Workload-Variant Autoscaling" "Signal-aware autoscaler that scales inference workloads on real-time inference metrics rather than generic infra signals."
+generate_stub "$DOCS_DIR/architecture/advanced/autoscaling/igw-hpa.md" "Inference Gateway HPA" "HorizontalPodAutoscaler integration for the Inference Gateway."
 generate_stub "$DOCS_DIR/api-reference/index.md" "API Reference" "API specification and reference documentation"
 generate_stub "$DOCS_DIR/api-reference/glossary.md" "Glossary" "Terminology and definitions for llm-d"
 generate_stub "$DOCS_DIR/resources/observability/index.md" "Observability" "Metrics, dashboards, and distributed tracing for llm-d"

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -158,8 +158,8 @@ cp_doc "$WIP/architecture/advanced/kv-management/prefix-cache-aware-routing.md" 
 
 # Architecture / Advanced / Autoscaling
 cp_doc "$WIP/architecture/advanced/autoscaling/README.md"                       "$DOCS_DIR/architecture/advanced/autoscaling/index.md"
-cp_doc "$WIP/architecture/advanced/autoscaling/wva.md"                         "$DOCS_DIR/architecture/advanced/autoscaling/workload-variant-autoscaling.md"
-cp_doc "$WIP/architecture/advanced/autoscaling/hpa-keda.md"                    "$DOCS_DIR/architecture/advanced/autoscaling/igw-hpa.md"
+cp_doc "$WIP/architecture/advanced/autoscaling/hpa-wva.md"                     "$DOCS_DIR/architecture/advanced/autoscaling/workload-variant-autoscaling.md"
+cp_doc "$WIP/architecture/advanced/autoscaling/hpa-epp.md"                     "$DOCS_DIR/architecture/advanced/autoscaling/igw-hpa.md"
 cp "$WIP/architecture/advanced/autoscaling/"*.svg "$DOCS_DIR/architecture/advanced/autoscaling/" 2>/dev/null || true
 
 # Architecture / Advanced / Batch
@@ -272,6 +272,14 @@ else
     cp_doc "$WIP/guides/monitoring/metrics.md"                "$DOCS_DIR/resources/observability/metrics.md"
     cp_doc "$WIP/guides/monitoring/tracing.md"                "$DOCS_DIR/resources/observability/tracing.md"
 fi
+# Upstream moved observability docs from docs/resources/observability/ to
+# docs/operations/observability/. Pulls from the current location; the
+# block above stays as a no-op fallback if the legacy paths re-appear.
+cp_doc "$WIP/operations/observability/README.md"  "$DOCS_DIR/resources/observability/index.md"
+cp_doc "$WIP/operations/observability/setup.md"   "$DOCS_DIR/resources/observability/setup.md"
+cp_doc "$WIP/operations/observability/metrics.md" "$DOCS_DIR/resources/observability/metrics.md"
+cp_doc "$WIP/operations/observability/tracing.md" "$DOCS_DIR/resources/observability/tracing.md"
+cp_doc "$WIP/operations/observability/promql.md"  "$DOCS_DIR/resources/observability/promql.md"
 
 # === Resources / Gateway ===
 cp_doc "$WIP/infrastructure/gateway/README.md"         "$DOCS_DIR/resources/gateway/index.md"
@@ -787,11 +795,12 @@ generate_stub "$DOCS_DIR/architecture/advanced/kv-management/index.md" "KV Cache
 generate_stub "$DOCS_DIR/architecture/advanced/kv-management/prefix-cache-aware-routing.md" "Prefix Cache Aware Routing" "Routing requests to maximize KV cache hits"
 generate_stub "$DOCS_DIR/architecture/advanced/kv-management/kv-indexer.md" "KV-Cache Indexer" "Globally consistent KV cache block tracking"
 generate_stub "$DOCS_DIR/architecture/advanced/kv-management/kv-offloader.md" "KV Offloader" "Tiered KV cache storage hierarchy"
-# Autoscaling sub-pages — upstream main currently ships only the README; stub
-# the sub-pages referenced by the sidebar until wva.md / hpa-keda.md land in
-# llm-d/llm-d. Self-heals once the cp_doc lines above produce real content.
+# Autoscaling sub-pages — kept as defensive stubs so the sidebar resolves
+# even when the cp_doc lines above silently no-op (e.g. against a snapshot
+# of upstream that doesn't have hpa-wva.md / hpa-epp.md). generate_stub is
+# null-safe, so it skips when the cp_doc lines produced real content.
 generate_stub "$DOCS_DIR/architecture/advanced/autoscaling/workload-variant-autoscaling.md" "Workload-Variant Autoscaling" "Signal-aware autoscaler that scales inference workloads on real-time inference metrics rather than generic infra signals."
-generate_stub "$DOCS_DIR/architecture/advanced/autoscaling/igw-hpa.md" "Inference Gateway HPA" "HorizontalPodAutoscaler integration for the Inference Gateway."
+generate_stub "$DOCS_DIR/architecture/advanced/autoscaling/igw-hpa.md" "EndPoint Picker HPA/KEDA Integration" "EndPoint Picker integration with HorizontalPodAutoscaler and KEDA."
 generate_stub "$DOCS_DIR/api-reference/index.md" "API Reference" "API specification and reference documentation"
 generate_stub "$DOCS_DIR/api-reference/glossary.md" "Glossary" "Terminology and definitions for llm-d"
 generate_stub "$DOCS_DIR/resources/observability/index.md" "Observability" "Metrics, dashboards, and distributed tracing for llm-d"

--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -107,6 +107,9 @@ mkdir -p \
     "$DOCS_DIR/guides/agentic-serving" \
     "$DOCS_DIR/resources/gateway" \
     "$DOCS_DIR/resources/observability" \
+    "$DOCS_DIR/resources/operations" \
+    "$DOCS_DIR/resources/operations/rollouts" \
+    "$DOCS_DIR/resources/infrastructure" \
     "$DOCS_DIR/resources/rdma" \
     "$DOCS_DIR/resources/infra-providers" \
     "$DOCS_DIR/api-reference" \
@@ -118,7 +121,7 @@ echo "    Copying content..."
 cp_doc "$WIP/getting-started/README.md"       "$DOCS_DIR/getting-started/index.md"
 cp_doc "$WIP/getting-started/quickstart.md"   "$DOCS_DIR/getting-started/quickstart.md"
 cp_doc "$WIP/getting-started/feature-matrix.md" "$DOCS_DIR/getting-started/feature-matrix.md"
-cp_doc "$WIP/getting-started/artifacts.md"    "$DOCS_DIR/getting-started/artifacts.md"
+cp_doc "$WIP/getting-started/accelerators.md" "$DOCS_DIR/getting-started/accelerators.md"
 
 # === Architecture ===
 cp_doc "$WIP/architecture/README.md"          "$DOCS_DIR/architecture/index.md"
@@ -140,15 +143,9 @@ cp_doc "$WIP/architecture/core/router/epp/configuration.md"     "$DOCS_DIR/archi
 cp_doc "$WIP/architecture/core/router/epp/datalayer.md"         "$DOCS_DIR/architecture/core/router/epp/datalayer.md"
 
 # Architecture / Advanced / Disaggregation
-cp_doc "$WIP/architecture/advanced/disaggregation/README.md"            "$DOCS_DIR/architecture/advanced/disaggregation/index.md"
-cp_doc "$WIP/architecture/advanced/disaggregation/operations-vllm.md"   "$DOCS_DIR/architecture/advanced/disaggregation/operations-vllm.md"
-
-# operations-sglang is not published on the site; point its link to the upstream source.
-if [[ -f "$DOCS_DIR/architecture/advanced/disaggregation/index.md" ]]; then
-    sed_inplace \
-        -e 's|\](operations-sglang\.md)|\](https://github.com/llm-d/llm-d/blob/main/docs/architecture/advanced/disaggregation/operations-sglang.md)|g' \
-        "$DOCS_DIR/architecture/advanced/disaggregation/index.md"
-fi
+cp_doc "$WIP/architecture/advanced/disaggregation/README.md"               "$DOCS_DIR/architecture/advanced/disaggregation/index.md"
+cp_doc "$WIP/architecture/advanced/disaggregation/operations-vllm.md"      "$DOCS_DIR/architecture/advanced/disaggregation/operations-vllm.md"
+cp_doc "$WIP/architecture/advanced/disaggregation/operations-sglang.md"    "$DOCS_DIR/architecture/advanced/disaggregation/operations-sglang.md"
 
 # Architecture / Advanced
 cp_doc "$WIP/architecture/advanced/latency-predictor.md" "$DOCS_DIR/architecture/advanced/latency-predictor.md"
@@ -285,6 +282,18 @@ cp_doc "$WIP/infrastructure/gateway/agentgateway.md"   "$DOCS_DIR/resources/gate
 
 cp_doc "$WIP/infrastructure/rdma/README.md"                  "$DOCS_DIR/resources/rdma/rdma-configuration.md"
 
+# === Operations (new pages) ===
+cp_doc "$WIP/operations/router.md"                          "$DOCS_DIR/resources/operations/router.md"
+cp_doc "$WIP/operations/readiness-probes.md"                "$DOCS_DIR/resources/operations/readiness-probes.md"
+cp_doc "$WIP/operations/rollouts/README.md"                 "$DOCS_DIR/resources/operations/rollouts/index.md"
+cp_doc "$WIP/operations/rollouts/adapter-rollout.md"        "$DOCS_DIR/resources/operations/rollouts/adapter-rollout.md"
+cp_doc "$WIP/operations/rollouts/blue-green-update.md"      "$DOCS_DIR/resources/operations/rollouts/blue-green-update.md"
+
+# === Infrastructure (new pages) ===
+cp_doc "$WIP/infrastructure/README.md"                      "$DOCS_DIR/resources/infrastructure/index.md"
+cp_doc "$WIP/infrastructure/multi-node.md"                  "$DOCS_DIR/resources/infrastructure/multi-node.md"
+cp_doc "$WIP/infrastructure/no-kubernetes-deployment.md"    "$DOCS_DIR/resources/infrastructure/no-kubernetes-deployment.md"
+
 # === Infrastructure Providers ===
 cp_doc "$WIP/infrastructure/providers/README.md"         "$DOCS_DIR/resources/infra-providers/index.md"
 cp_doc "$WIP/infrastructure/providers/aks/README.md"     "$DOCS_DIR/resources/infra-providers/aks.md"
@@ -303,6 +312,8 @@ cp_doc "$WIP/api-reference/inferencemodelrewrite.md" "$DOCS_DIR/api-reference/in
 cp_doc "$WIP/api-reference/endpointpickerconfig.md"  "$DOCS_DIR/api-reference/endpointpickerconfig.md"
 cp_doc "$WIP/api-reference/epp-http-headers.md"      "$DOCS_DIR/api-reference/epp-http-headers.md"
 cp_doc "$WIP/api-reference/epp-http-apis.md"         "$DOCS_DIR/api-reference/epp-http-apis.md"
+cp_doc "$WIP/api-reference/epp-grpc-apis.md"         "$DOCS_DIR/api-reference/epp-grpc-apis.md"
+cp_doc "$WIP/api-reference/artifacts.md"             "$DOCS_DIR/api-reference/artifacts.md"
 
 # === Accelerators ===
 cp_doc "$WIP/getting-started/accelerators.md"        "$DOCS_DIR/accelerators/index.md"

--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -134,7 +134,7 @@ const sidebars: SidebarsConfig = {
               link: {type: 'doc', id: 'architecture/advanced/autoscaling/index'},
               items: [
                 'architecture/advanced/autoscaling/workload-variant-autoscaling',
-                'architecture/advanced/autoscaling/igw-hpa',
+                {type: 'doc', id: 'architecture/advanced/autoscaling/igw-hpa', label: 'EndPoint Picker HPA/KEDA Integration'},
               ],
             },
             {
@@ -170,9 +170,10 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Infrastructure & Environments',
       collapsed: true,
+      // Render the Infrastructure Reference content on the section page itself
+      // instead of as a separate child entry.
+      link: {type: 'doc', id: 'resources/infrastructure/index'},
       items: [
-        {type: 'doc', id: 'resources/infrastructure/index', label: 'Infrastructure Reference'},
-        {type: 'doc', id: 'resources/infrastructure/multi-node', label: 'Multi-Node Serving Orchestration'},
         {
           type: 'category',
           label: 'Kubernetes Infrastructure Providers',
@@ -187,11 +188,9 @@ const sidebars: SidebarsConfig = {
             'resources/infra-providers/openshift-aws',
           ],
         },
-        {type: 'doc', id: 'resources/infrastructure/no-kubernetes-deployment', label: 'Non-K8s & Bare-Metal Deployments'},
-        {type: 'doc', id: 'resources/rdma/rdma-configuration', label: 'RDMA & Networking Configuration'},
         {
           type: 'category',
-          label: 'Gateway & Ingress Resources',
+          label: 'Kubernetes Gateways',
           collapsed: true,
           link: {type: 'doc', id: 'resources/gateway/index'},
           items: [
@@ -200,6 +199,9 @@ const sidebars: SidebarsConfig = {
             'resources/gateway/agentgateway',
           ],
         },
+        {type: 'doc', id: 'resources/infrastructure/multi-node', label: 'Kubernetes Multi-Node Orchestration'},
+        {type: 'doc', id: 'resources/infrastructure/no-kubernetes-deployment', label: 'Non-K8s & Bare-Metal Deployments'},
+        {type: 'doc', id: 'resources/rdma/rdma-configuration', label: 'RDMA & Networking Configuration'},
       ],
     },
     // ==================== References ====================

--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -7,7 +7,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Getting Started',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'getting-started/index'},
       items: [
         'getting-started/quickstart',
@@ -24,7 +24,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Core',
-          collapsed: false,
+          collapsed: true,
           items: [
             'architecture/core/inferencepool',
             {
@@ -53,12 +53,12 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Advanced',
-          collapsed: false,
+          collapsed: true,
           items: [
             {
               type: 'category',
               label: 'Disaggregation',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/disaggregation/index'},
               items: [
                 'architecture/advanced/disaggregation/operations-vllm',
@@ -68,7 +68,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'KV Cache Management',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/kv-management/index'},
               items: [
                 'architecture/advanced/kv-management/prefix-cache-aware-routing',
@@ -79,7 +79,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'Autoscaling',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/autoscaling/index'},
               items: [
                 'architecture/advanced/autoscaling/workload-variant-autoscaling',
@@ -89,7 +89,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'Batch Processing',
-              collapsed: false,
+              collapsed: true,
               link: {type: 'doc', id: 'architecture/advanced/batch/index'},
               items: [
                 'architecture/advanced/batch/batch-gateway',
@@ -104,7 +104,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Well-Lit Paths',
-      collapsed: false,
+      collapsed: true,
       link: {type: 'doc', id: 'guides/index'},
       items: [
         'guides/optimized-baseline',
@@ -135,7 +135,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Gateway',
-          collapsed: false,
+          collapsed: true,
           link: {type: 'doc', id: 'resources/gateway/index'},
           items: [
             'resources/gateway/istio',
@@ -146,7 +146,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Infrastructure Providers',
-          collapsed: false,
+          collapsed: true,
           link: {type: 'doc', id: 'resources/infra-providers/index'},
           items: [
             'resources/infra-providers/aks',
@@ -160,7 +160,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Observability',
-          collapsed: false,
+          collapsed: true,
           link: {type: 'doc', id: 'resources/observability/index'},
           items: [
             'resources/observability/setup',

--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -3,21 +3,71 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 // Sidebar structure matching docs/wip-docs-new/outline.md exactly
 const sidebars: SidebarsConfig = {
   docsSidebar: [
+    // ==================== Introduction (standalone) ====================
+    {type: 'doc', id: 'getting-started/index', label: 'Introduction to llm-d'},
     // ==================== Getting Started ====================
     {
       type: 'category',
       label: 'Getting Started',
-      collapsed: true,
-      link: {type: 'doc', id: 'getting-started/index'},
+      collapsed: false,
       items: [
         'getting-started/quickstart',
-        'getting-started/artifacts',
+        {type: 'doc', id: 'getting-started/accelerators', label: 'Supported Accelerators'},
       ],
     },
-    // ==================== Architecture ====================
+    // ==================== Well-Lit Paths ====================
     {
       type: 'category',
-      label: 'Architecture',
+      label: 'Well-Lit Paths',
+      collapsed: false,
+      link: {type: 'doc', id: 'guides/index'},
+      items: [
+        {
+          type: 'category',
+          label: 'Foundations',
+          collapsed: false,
+          items: [
+            {type: 'doc', id: 'guides/optimized-baseline', label: 'Deploy an Optimized Baseline'},
+            {type: 'doc', id: 'guides/predicted-latency', label: 'Route Requests by Predicted Latency'},
+            {type: 'doc', id: 'guides/precise-prefix-cache-routing', label: 'Enable Precise Prefix-Cache Aware Routing'},
+            {type: 'doc', id: 'guides/tiered-prefix-cache', label: 'Configure a Tiered Prefix Cache'},
+            {type: 'doc', id: 'guides/pd-disaggregation', label: 'Deploy Prefill/Decode Disaggregation'},
+            {type: 'doc', id: 'guides/wide-expert-parallelism', label: 'Scale MoE Models with Wide Expert Parallelism'},
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Workloads',
+          collapsed: false,
+          items: [
+            {type: 'doc', id: 'guides/agentic-serving/index', label: 'Serve Agentic Workloads'},
+            {type: 'doc', id: 'guides/multimodal-serving', label: 'Serve Multimodal Workloads'},
+            {
+              type: 'category',
+              label: 'Serve Batch Workloads',
+              collapsed: true,
+              items: [
+                {type: 'doc', id: 'guides/asynchronous-processing', label: 'Asynchronous Processing'},
+                {type: 'doc', id: 'guides/batch-gateway', label: 'Batch Gateway'},
+              ],
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Traffic Control & Autoscaling',
+          collapsed: false,
+          items: [
+            {type: 'doc', id: 'guides/flow-control', label: 'Apply Flow Control and Fairness'},
+            {type: 'doc', id: 'guides/workload-autoscaling', label: 'Autoscale your Inference Pool'},
+          ],
+        },
+      ],
+    },
+    // ==================== Concepts (Architecture) ====================
+    {
+      type: 'category',
+      label: 'Concepts (Architecture)',
       collapsed: true,
       link: {type: 'doc', id: 'architecture/index'},
       items: [
@@ -52,7 +102,7 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
-          label: 'Advanced',
+          label: 'Capabilities',
           collapsed: true,
           items: [
             {
@@ -62,6 +112,7 @@ const sidebars: SidebarsConfig = {
               link: {type: 'doc', id: 'architecture/advanced/disaggregation/index'},
               items: [
                 'architecture/advanced/disaggregation/operations-vllm',
+                'architecture/advanced/disaggregation/operations-sglang',
               ],
             },
             'architecture/advanced/latency-predictor',
@@ -100,52 +151,31 @@ const sidebars: SidebarsConfig = {
         },
       ],
     },
-    // ==================== Well-Lit Paths ====================
+    // ==================== Operations ====================
     {
       type: 'category',
-      label: 'Well-Lit Paths',
+      label: 'Operations & Monitoring',
       collapsed: true,
-      link: {type: 'doc', id: 'guides/index'},
       items: [
-        'guides/optimized-baseline',
-        'guides/precise-prefix-cache-routing',
-        'guides/tiered-prefix-cache',
-        'guides/asynchronous-processing',
-        'guides/flow-control',
-        'guides/pd-disaggregation',
-        'guides/predicted-latency',
-        'guides/wide-expert-parallelism',
-        'guides/workload-autoscaling',
-        'guides/agentic-serving/index',
-        {
-          type: 'doc',
-          id: 'guides/multimodal-serving',
-          label: 'Multimodal Serving',
-        },
-        'guides/batch-gateway',
-        'guides/no-kubernetes-deployment',
+        {type: 'doc', id: 'resources/observability/metrics', label: 'Monitoring & Metrics'},
+        {type: 'doc', id: 'resources/observability/tracing', label: 'Tracing'},
+        {type: 'doc', id: 'resources/observability/promql', label: 'PromQL'},
+        {type: 'doc', id: 'resources/operations/readiness-probes', label: 'Readiness Probes'},
+        {type: 'doc', id: 'resources/operations/rollouts/index', label: 'Rollouts'},
+        {type: 'doc', id: 'resources/operations/router', label: 'Router Operations Guide'},
       ],
     },
-    // ==================== Resources ====================
+    // ==================== Infrastructure & Environments ====================
     {
       type: 'category',
-      label: 'Resources',
+      label: 'Infrastructure & Environments',
       collapsed: true,
       items: [
+        {type: 'doc', id: 'resources/infrastructure/index', label: 'Infrastructure Reference'},
+        {type: 'doc', id: 'resources/infrastructure/multi-node', label: 'Multi-Node Serving Orchestration'},
         {
           type: 'category',
-          label: 'Gateway',
-          collapsed: true,
-          link: {type: 'doc', id: 'resources/gateway/index'},
-          items: [
-            'resources/gateway/istio',
-            'resources/gateway/gke',
-            'resources/gateway/agentgateway',
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Infrastructure Providers',
+          label: 'Kubernetes Infrastructure Providers',
           collapsed: true,
           link: {type: 'doc', id: 'resources/infra-providers/index'},
           items: [
@@ -157,29 +187,44 @@ const sidebars: SidebarsConfig = {
             'resources/infra-providers/openshift-aws',
           ],
         },
+        {type: 'doc', id: 'resources/infrastructure/no-kubernetes-deployment', label: 'Non-K8s & Bare-Metal Deployments'},
+        {type: 'doc', id: 'resources/rdma/rdma-configuration', label: 'RDMA & Networking Configuration'},
         {
           type: 'category',
-          label: 'Observability',
+          label: 'Gateway & Ingress Resources',
           collapsed: true,
-          link: {type: 'doc', id: 'resources/observability/index'},
+          link: {type: 'doc', id: 'resources/gateway/index'},
           items: [
-            'resources/observability/setup',
-            'resources/observability/metrics',
-            'resources/observability/tracing',
-            'resources/observability/promql',
+            'resources/gateway/istio',
+            'resources/gateway/gke',
+            'resources/gateway/agentgateway',
           ],
         },
-        'resources/rdma/rdma-configuration',
       ],
     },
-    // ==================== API Reference ====================
+    // ==================== References ====================
     {
       type: 'category',
-      label: 'API Reference',
+      label: 'References',
       collapsed: true,
       link: {type: 'doc', id: 'api-reference/index'},
       items: [
-        'api-reference/glossary',
+        {
+          type: 'category',
+          label: 'Kubernetes APIs',
+          collapsed: true,
+          items: [
+            {type: 'doc', id: 'api-reference/inferencepool', label: 'InferencePool'},
+            {type: 'doc', id: 'api-reference/inferenceobjective', label: 'InferenceObjective'},
+            {type: 'doc', id: 'api-reference/inferencemodelrewrite', label: 'InferenceModelRewrite'},
+          ],
+        },
+        {type: 'doc', id: 'api-reference/endpointpickerconfig', label: 'Component Config: EndpointPickerConfig'},
+        {type: 'doc', id: 'api-reference/epp-http-apis', label: 'HTTP APIs'},
+        {type: 'doc', id: 'api-reference/epp-grpc-apis', label: 'RPC APIs'},
+        {type: 'doc', id: 'api-reference/epp-http-headers', label: 'HTTP Headers'},
+        {type: 'doc', id: 'api-reference/glossary', label: 'Glossary'},
+        {type: 'doc', id: 'api-reference/artifacts', label: 'Artifacts'},
       ],
     },
   ],

--- a/preview/src/css/custom.css
+++ b/preview/src/css/custom.css
@@ -346,3 +346,47 @@ table th {
 .theme-doc-version-banner {
   border-radius: 6px;
 }
+
+/* ============================================
+   Sidebar visual hierarchy
+   ============================================ */
+
+/* All sidebar items: 14px */
+.menu__link {
+  font-size: 0.875rem;
+}
+
+/* Top-level categories AND standalone top-level doc links (the main sections): semi-bold */
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link,
+.theme-doc-sidebar-item-link-level-1 > .menu__link {
+  font-weight: 600;
+}
+
+/* Sub-categories (pages with sub-pages) and nested leaf doc links: normal weight */
+.theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible > .menu__link,
+.theme-doc-sidebar-item-category-level-3 > .menu__list-item-collapsible > .menu__link,
+.theme-doc-sidebar-item-category-level-4 > .menu__list-item-collapsible > .menu__link,
+.theme-doc-sidebar-item-link-level-2 > .menu__link,
+.theme-doc-sidebar-item-link-level-3 > .menu__link,
+.theme-doc-sidebar-item-link-level-4 > .menu__link,
+.theme-doc-sidebar-item-link-level-5 > .menu__link {
+  font-weight: 400;
+}
+
+/* +4px extra spacing between items inside the sidebar */
+.theme-doc-sidebar-menu .menu__list-item {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+/* 24px breathing room between top-level sidebar sections (overrides the +4px above) */
+.theme-doc-sidebar-menu > .menu__list-item:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+
+/* +8px extra space above sub-category headers (not the first sibling) so
+   adjacent expanded sub-sections aren't visually crammed together. */
+.theme-doc-sidebar-item-category-level-2:not(:first-child),
+.theme-doc-sidebar-item-category-level-3:not(:first-child) {
+  margin-top: 8px;
+}

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -125,6 +125,12 @@ else
     # Static assets (logos referenced by the synced footer/navbar, e.g. the CNCF
     # logo) come from main too, so they exist for every version's build.
     cp -r "$PROJECT_DIR/preview/static/." "${WORKTREE_PATH}/preview/static/"
+    # Defensive: also explicitly copy releases.json so every versioned build
+    # ships the same release list as main. Without this, Netlify's worktree
+    # build relies on a fresh GitHub API fetch which can silently fail
+    # (rate-limited, network), leaving the versioned build with no
+    # releases.json and the dropdown shows only "dev".
+    cp -f "$PROJECT_DIR/preview/static/releases.json" "${WORKTREE_PATH}/preview/static/releases.json" 2>/dev/null || true
 
     # Apply fixups for known stale GitHub links in committed release-branch content.
     # These patch specific link targets that changed in upstream after the branch was cut.


### PR DESCRIPTION
## Summary

Reshapes `/docs/dev/` left nav into the new IA and lands shared sidebar visual hierarchy CSS. Two commits:

1. **`0ab45a4` — Collapse all left-nav categories by default.** Docusaurus auto-expands the category containing the current page, so navigation context is preserved.
2. **`c7550f7` — Restructure dev left nav + visual hierarchy + sync updates.** See below.

### Sidebar restructure (`preview/sidebars.ts`)

- Add **"Introduction to llm-d"** standalone link at the top
- Add **"Supported Accelerators"** page under Getting Started
- Rename **Architecture → Concepts (Architecture)**, **Advanced → Capabilities**
- Rename **Guides → Well-Lit Paths**, reorganize into **Foundations / Workloads / Traffic Control & Autoscaling**
- Add Disaggregation/SGLang, Agentic Serving, Multimodal Serving, Batch Gateway pages
- Split **Resources** into **Operations & Monitoring** + **Infrastructure & Environments**
- Rename **API Reference → References** and add API pages
- Page-level renames (e.g. *Optimized Baseline → Deploy an Optimized Baseline*)
- Move **Well-Lit Paths** above **Concepts (Architecture)**
- Expand **Getting Started** and **Well-Lit Paths** (with their sub-categories) by default

### Visual hierarchy (`preview/src/css/custom.css`)

- 14px font size on all sidebar items
- Semi-bold top-level categories and standalone L1 links
- Normal weight on sub-categories and leaf doc links
- +4px spacing between items, 24px between top-level sections, +8px above non-first sub-categories

### Sync (`preview/scripts/sync-docs.sh`)

Pulls the new pages from `llm-d/llm-d@main` (accelerators, well-lit-paths/capabilities, workloads/agentic-serving, workloads/batch-serving, multimodal, etc.).

## Companion PR

- v0.7.0 sidebar parity: #374 (target `release-0.7.0`) — applies the same CSS hierarchy + rename/reorder/expand to the stable v0.7.0 nav.

## Test plan

- [x] `LLMD_REPO=/tmp/llm-d-work npm run build:all` succeeds locally; `/docs/dev/getting-started` renders the new nav structure with visual hierarchy applied
- [x] All synced doc IDs resolve (no broken sidebar refs)
- [ ] Reviewer to spot-check the dev sidebar against Netlify deploy preview

## Related Issues
#368 