### PR TITLE
Auto Label Blog Posts

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,7 @@
 # Blog posts
 Blog Post:
   - changed-files:
-    - any-glob-to-any-file: 'blogs/*.md'
+    - any-glob-to-any-file: 'blog/**/*.md'
 action:
   - changed-files:
     - any-glob-to-any-file: '.github/workflows/*.yml'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+# .github/labeler.yml
+
+# Label definitions
+
+# Blog posts
+Blog Post:
+  - changed-files:
+    - any-glob-to-any-file: 'blogs/*.md'
+action:
+  - changed-files:
+    - any-glob-to-any-file: '.github/workflows/*.yml'
+    - any-glob-to-any-file: '.github/workflows/*.yaml'

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/labeler@v6
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        config-path: .github/labeler.yml
+      - uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,18 @@
+name: Auto-label
+on:
+  pull_request_target:
+    types: [opened]
+    branches: [main]
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v6
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        config-path: .github/labeler.yml

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,7 +1,7 @@
 name: Auto-label
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, reopened, synchronize]
     branches: [main]
 
 jobs:


### PR DESCRIPTION
## What does this PR do?

Auto-labels blog posts as `Blog Post` when a new blog is submitted as a PR.

## Why is this change needed?

Removes the need to have the blog posts hand-labeled

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [ ] Site builds successfully (`npm run build:all`)
- [ ] Check links after buildling (`npm run check-links`)
- [ ] Manual testing performed (`npm run serve`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [ ] Tests pass locally (`npm test`)
- [ ] Site builds without errors (`npm run build:all`)
- [ ] No broken links after building full site (`npm run check-links`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
