### PR TITLE
fix(sync): point Batch Gateway Deployment Guide link to GitHub

### DIFF
--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -570,7 +570,7 @@ find "$DOCS_DIR" -name "*.md" -print0 | while IFS= read -r -d '' file; do
         -e 's|\](../../../guides/asynchronous-processing)|\](https://github.com/llm-d/llm-d/tree/main/guides/asynchronous-processing)|g' \
         -e 's|\](../../../../guides/tiered-prefix-cache)|\](/guides/tiered-prefix-cache)|g' \
         -e 's|\](/guides/tiered-prefix-cache)|\](/guides/tiered-prefix-cache)|g' \
-        -e 's|\](../../../../guides/batch-gateway)|\](/guides/batch-gateway)|g' \
+        -e 's|\](../../../../guides/batch-gateway)|\](https://github.com/llm-d/llm-d/tree/main/guides/batch-gateway)|g' \
         -e 's|\](/guides/batch-gateway)|\](/guides/batch-gateway)|g' \
         -e 's|\](../../../guides/batch-gateway)|\](/guides/batch-gateway)|g' \
         -e 's|\](../../../guides/asynchronous-processing)|\](/guides/asynchronous-processing)|g' \


### PR DESCRIPTION
## Problem

On the dev docs, the **Batch Gateway Deployment Guide** link in the *Related* section is broken — it points back to the well-lit-path page itself instead of the deployment guide:

- https://llm-d.ai/docs/dev/well-lit-paths/batch-gateway#related → link resolves to `/docs/dev/well-lit-paths/batch-gateway` (self-link)
- https://llm-d.ai/docs/dev/architecture/advanced/batch/batch-gateway#related → same wrong target

## Root cause

This is a sync-transform bug, not a content issue in `llm-d/llm-d` (the relative link renders fine on GitHub).

The source files (`docs/well-lit-paths/workloads/batch-serving/batch-gateway.md` and `docs/architecture/advanced/batch/batch-gateway.md`) use a **4-level** relative link: `../../../../guides/batch-gateway`.

In `preview/scripts/sync-docs.sh`:
- line 569 maps the **3-level** form `../../../guides/batch-gateway` → the GitHub guides URL ✅
- line 573 mapped the **4-level** form → the *internal* `/guides/batch-gateway`, whose doc slug is `/well-lit-paths/batch-gateway` (set at line 277) → so the link resolved back to the page itself ❌

The files actually use the 4-level form, so the broken rule (573) is the one that fires.

## Fix

Point the 4-level rule at the GitHub guides directory, matching the existing 3-level rule one line above. One line changed in `preview/scripts/sync-docs.sh`. The `asynchronous-processing` link and the internal `tiered-prefix-cache` link are unaffected.

