### PR TITLE
banner: announce llm-d 0.8

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -193,9 +193,9 @@ const config = {
         respectPrefersColorScheme: true,
       },
       announcementBar: {
-        id: "llm-d-v0-7-release",
+        id: "llm-d-v0-8-release",
         content:
-          '🎉 <b>llm-d 0.7 is now available!</b> Explore our completely revamped documentation with comprehensive guides, architecture deep-dives, and production deployment patterns. <a target="_self" rel="noopener noreferrer" href="/docs/getting-started/quickstart"><b>Browse the docs →</b></a>',
+          '🎉 <b>llm-d 0.8 is here!</b> Multimodal, batch &amp; flow-control graduate to production, with broader accelerator support and initial RL. <a target="_self" rel="noopener noreferrer" href="/docs/getting-started/quickstart"><b>See what\'s new →</b></a>',
         backgroundColor: '#000000',
         textColor: '#fff',
         isCloseable: true,

--- a/preview/docusaurus.config.ts
+++ b/preview/docusaurus.config.ts
@@ -268,9 +268,9 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     announcementBar: {
-      id: 'llm-d-v0-7-release',
+      id: 'llm-d-v0-8-release',
       content:
-        '🎉 <b>llm-d 0.7 is now available!</b> Explore our completely revamped documentation with comprehensive guides, architecture deep-dives, and production deployment patterns. <a target="_self" rel="noopener noreferrer" href="/docs/getting-started/quickstart"><b>Browse the docs →</b></a>',
+        '🎉 <b>llm-d 0.8 is here!</b> Multimodal, batch &amp; flow-control graduate to production, with broader accelerator support and initial RL. <a target="_self" rel="noopener noreferrer" href="/docs/getting-started/quickstart"><b>See what\'s new →</b></a>',
       backgroundColor: '#000000',
       textColor: '#fff',
       isCloseable: true,


### PR DESCRIPTION
## What

Updates the site announcement banner to:

> 🎉 **llm-d 0.8 is here!** Multimodal, batch & flow-control graduate to production, with broader accelerator support and initial RL. **See what's new →**

The **See what's new →** link points to `/docs/getting-started/quickstart` (i.e. https://llm-d.ai/docs/getting-started/quickstart in production). The copy reflects the v0.8 release themes.

## Files changed

The banner is defined in two configs (root site + docs/preview); both are updated so it's consistent across the landing/blog/community pages and the docs pages:
- `docusaurus.config.js`
- `preview/docusaurus.config.ts`

## Notes

- **Bumped the `announcementBar` id** (`llm-d-v0-7-release` → `llm-d-v0-8-release`). The banner is `isCloseable`, and Docusaurus remembers dismissals per id — without a new id, anyone who had dismissed the 0.7 banner would never see the 0.8 one.
- The link is kept **relative** (`/docs/getting-started/quickstart`), matching the previous banner. It resolves to the production URL above and also works correctly on deploy previews.
