### PR TITLE
fix(navbar): hide Slack icon in header on mobile

### DIFF
--- a/preview/src/css/custom.css
+++ b/preview/src/css/custom.css
@@ -645,6 +645,11 @@ html:not([data-theme='dark']) .footer-socials img {
   .navbar__inner .navbar-github-stars {
     display: none !important;
   }
+  /* Hide the Slack icon in the header on mobile to avoid overlapping the
+     logo; it remains available in the collapsed (hamburger) menu. */
+  .navbar__inner .navbar-slack-item {
+    display: none !important;
+  }
 }
 
 @media screen and (max-width: 996px) {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -654,6 +654,11 @@ html:not([data-theme='dark']) .footer-socials img {
   .navbar__inner .navbar-github-stars {
     display: none !important;
   }
+  /* Hide the Slack icon in the header on mobile to avoid overlapping the
+     logo; it remains available in the collapsed (hamburger) menu. */
+  .navbar__inner .navbar-slack-item {
+    display: none !important;
+  }
 }
 
 @media screen and (max-width: 996px) {


### PR DESCRIPTION
## Problem

On mobile, the header Slack icon overlaps the llm-d logo (reported from a deploy-preview check). The Slack link is also present in the collapsed hamburger menu, which is the correct/intended place for it on mobile.

## Fix

Hide the header Slack icon on mobile (`<=700px`), scoped to `.navbar__inner` so only the **header** instance is hidden — the Slack link in the `.navbar-sidebar` (hamburger menu) stays. This mirrors the existing rule for the GitHub-stars item one line above:

```css
@media screen and (max-width: 700px) {
  .navbar__inner .navbar-github-stars { display: none !important; }
  .navbar__inner .navbar-slack-item   { display: none !important; }  /* added */
}
```

Applied to both stylesheets, since the navbar exists in both:
- `src/css/custom.css` (root site: landing/blog/community)
- `preview/src/css/custom.css` (docs pages)

Desktop (`>700px`) is unchanged — the Slack button remains in the header.

