### PR TITLE
feat(docs): Add Envoy AI Gateway guide to the sidebar

### DIFF
--- a/preview/sidebars.ts
+++ b/preview/sidebars.ts
@@ -192,6 +192,8 @@ const sidebars: SidebarsConfig = {
             'resources/gateway/istio',
             'resources/gateway/gke',
             'resources/gateway/agentgateway',
+            'resources/gateway/envoy-ai-gateway',
+            'resources/gateway/install-crds',
           ],
         },
         {type: 'doc', id: 'resources/infrastructure/multi-node', label: 'Kubernetes Multi-Node Orchestration'},


### PR DESCRIPTION
## What does this PR do?

Adds the Envoy AI Gateway guide to the sidebar. Follow-up of https://github.com/llm-d/llm-d/pull/1788

## Why is this change needed?

Without it the documentation is incomplete and missing the link to the Envoy AI Gateway guide.

## How was this tested?

- [ ] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build:all`)
- [ ] Check links after buildling (`npm run check-links`)
- [x] Manual testing performed (`npm run serve`)

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [ ] Tests pass locally (`npm test`)
- [ ] Site builds without errors (`npm run build:all`)
- [ ] No broken links after building full site (`npm run check-links`)
- [ ] Documentation updated (if applicable)

## Related Issues

Related to https://github.com/llm-d/llm-d/pull/1788
