### PR TITLE
fix(build): repoint stale mooncake helper links in release-0.8.0 docs

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -163,6 +163,9 @@ else
         -e 's|github.com/llm-d/llm-d/tree/main/guides/prereq/gateways/README\.md|github.com/llm-d/llm-d/tree/main/docs/infrastructure/gateway|g' \
         -e 's|github.com/llm-d/llm-d/tree/main/guides/prereq/gateways/\([^"]*\)\.md|github.com/llm-d/llm-d/tree/main/docs/infrastructure/gateway/\1.md|g' \
         -e 's|github.com/llm-d/llm-d/tree/main/docs/resources/gateway|github.com/llm-d/llm-d/tree/main/docs/infrastructure/gateway|g' \
+        -e 's|](\(\.\./\)*helpers/mooncake-master-store/base/configmap\.yaml)|](https://github.com/llm-d/llm-d/blob/main/helpers/mooncake-master-store/base/configmap.yaml)|g' \
+        -e 's|](\(\.\./\)*helpers/mooncake-master-store/)|](https://github.com/llm-d/llm-d/tree/main/helpers/mooncake-master-store)|g' \
+        -e 's|](\(\.\./\)*helpers/mooncake-client/)|](https://github.com/llm-d/llm-d/tree/main/helpers/mooncake-client)|g' \
         "$file"
     done < <(find "${WORKTREE_PATH}/preview/docs" -name "*.md" -print0)
 


### PR DESCRIPTION
## Problem
The **Test deployment** check (`build:all` + `check-links`) is failing on **every** open PR with 3 broken links on the v0.8.0 versioned docs:

```
/docs/architecture/advanced/kv-management/kv-offloader
  /helpers/mooncake-master-store        -> HTTP 404
  /helpers/mooncake-client              -> HTTP 404
  /helpers/mooncake-master-store/base/configmap.yaml -> HTTP 404
```

`release-0.8.0` was cut just before llm-d/llm-d#1962, so its committed `kv-offloader.md` still uses relative `](../../../../helpers/mooncake-*)` links. These overshoot the docs tree and resolve to root-relative `/helpers/mooncake-*`, which the site doesn't publish → 404. (main already points these at GitHub; v0.7.0 predates the content and is clean.)

## Fix
Extend the existing "Apply fixups for known stale GitHub links in committed release-branch content" block in `scripts/build-all.sh` to repoint the three mooncake links at GitHub — matching what main does post-#1962. Versioned content on the release branch is left untouched (patched at build time only).

## Verified
- Applied the fixups to `release-0.8.0`'s `kv-offloader.md`: all 3 relative links convert to GitHub URLs, and each target returns HTTP 200.
- `npm run build:all` + `npm run check-links` → 0 broken links across dev / 0.8.0 / 0.7.0.

Unblocks #396 and all other open PRs.