### PR TITLE
fix(navbar): prevent header overlap at ~1000px; keep GitHub/Slack icons on mobile

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -248,6 +248,15 @@ const config = {
               '<iframe src="https://ghbtns.com/github-btn.html?user=llm-d&repo=llm-d&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub Star" style="vertical-align: middle;"></iframe>',
           },
           {
+            // Plain GitHub icon (no star count). Hidden on wide screens (the star
+            // button above is shown); swapped in at narrow/mobile widths via CSS.
+            type: "html",
+            position: "right",
+            className: "navbar-github-icon",
+            value:
+              '<a href="https://github.com/llm-d/llm-d" class="navbar-github-button" target="_blank" rel="noopener noreferrer" aria-label="GitHub" title="GitHub"><svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.05-.02-2.06-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.95 0-1.31.47-2.39 1.24-3.23-.13-.3-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.48 11.48 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.25 2.88.12 3.18.77.84 1.24 1.92 1.24 3.23 0 4.62-2.8 5.64-5.48 5.94.43.37.81 1.1.81 2.22 0 1.6-.02 2.89-.02 3.28 0 .32.22.7.82.58A12.01 12.01 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z"></path></svg></a>',
+          },
+          {
             type: 'html',
             position: 'right',
             className: 'navbar-slack-item',

--- a/preview/docusaurus.config.ts
+++ b/preview/docusaurus.config.ts
@@ -308,6 +308,14 @@ const config: Config = {
           value: '<iframe src="https://ghbtns.com/github-btn.html?user=llm-d&repo=llm-d&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub Star" style="vertical-align: middle;"></iframe>',
         },
         {
+          // Plain GitHub icon (no star count). Hidden on wide screens (the star
+          // button above is shown); swapped in at narrow/mobile widths via CSS.
+          type: 'html',
+          position: 'right',
+          className: 'navbar-github-icon',
+          value: '<a href="https://github.com/llm-d/llm-d" class="navbar-github-button" target="_blank" rel="noopener noreferrer" aria-label="GitHub" title="GitHub"><svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.05-.02-2.06-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.95 0-1.31.47-2.39 1.24-3.23-.13-.3-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.48 11.48 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.25 2.88.12 3.18.77.84 1.24 1.92 1.24 3.23 0 4.62-2.8 5.64-5.48 5.94.43.37.81 1.1.81 2.22 0 1.6-.02 2.89-.02 3.28 0 .32.22.7.82.58A12.01 12.01 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z"></path></svg></a>',
+        },
+        {
           type: 'html',
           position: 'right',
           className: 'navbar-slack-item',

--- a/preview/src/css/custom.css
+++ b/preview/src/css/custom.css
@@ -614,6 +614,27 @@ html:not([data-theme='dark']) .footer-socials img {
   width: 150px !important;
 }
 
+/* Plain GitHub icon-link (octocat, no star count). Hidden on wide screens where
+   the star button above is shown; swapped in at narrow/mobile widths below. */
+.navbar-github-icon {
+  display: none;
+}
+.navbar-github-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 8px;
+  color: var(--ifm-navbar-link-color);
+  border-radius: 6px;
+  transition: background-color 0.2s ease;
+}
+.navbar-github-button:hover {
+  background-color: #f0f0f0;
+  color: var(--ifm-navbar-link-hover-color);
+}
+[data-theme='dark'] .navbar-github-button:hover {
+  background-color: #1a1a1a;
+}
+
 /* Navbar Slack button */
 .navbar-slack-button {
   display: inline-flex;
@@ -641,29 +662,54 @@ html:not([data-theme='dark']) .footer-socials img {
   background-color: #1a1a1a;
 }
 
-@media screen and (max-width: 700px) {
-  .navbar__inner .navbar-github-stars {
-    display: none !important;
-  }
-  /* Hide the Slack icon in the header on mobile to avoid overlapping the
-     logo; it remains available in the collapsed (hamburger) menu. */
-  .navbar__inner .navbar-slack-item {
-    display: none !important;
-  }
-}
-
 @media screen and (max-width: 996px) {
   /* Reserve space for the absolutely-positioned search bar (144px + 16px = 160px) */
   .navbar__items--right {
     padding-right: 164px !important;
   }
-  /* Compact GitHub iframe so both items fit before search overlay */
-  .navbar-github-stars iframe {
-    width: 80px !important;
+  /* Swap the star button for the plain GitHub icon (no count) at narrow widths;
+     keep it (and the Slack icon) in the header down through mobile. */
+  .navbar-github-stars {
+    display: none !important;
+  }
+  .navbar-github-icon {
+    display: flex !important;
   }
   /* Slack icon only — hide text label */
   .slack-label {
     display: none !important;
+  }
+}
+
+/* ===== Narrow-desktop navbar (997px–1200px) =====
+   Above Docusaurus's 996px hamburger breakpoint the full navbar stays inline,
+   but the left group (…version dropdown) and right group (GitHub star…) don't
+   fit and overlap under justify-content: space-between — the logo runs into
+   "Documentation" and the version dropdown runs into the GitHub star. Compact
+   the widest items so the row fits without prematurely raising the (JS-gated)
+   996px mobile breakpoint. */
+@media screen and (min-width: 997px) and (max-width: 1200px) {
+  /* Tighter inter-item spacing for the left links */
+  .navbar__item.navbar__link,
+  .navbar__items--left > .navbar__link {
+    padding-left: 0.4rem;
+    padding-right: 0.4rem;
+  }
+  /* Drop the fixed 10rem/9rem version-dropdown reservation; size to content */
+  .navbar__items--left > .dropdown,
+  .navbar__items--left > .navbar__item.dropdown {
+    min-width: 0;
+  }
+  .navbar__items--left > .dropdown > .navbar__link {
+    min-width: 0;
+  }
+  /* Slack: icon only (full label returns at wider widths) */
+  .navbar-slack-button .slack-label {
+    display: none;
+  }
+  /* Compact the GitHub star button */
+  .navbar-github-stars iframe {
+    width: 90px !important;
   }
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -623,6 +623,27 @@ html:not([data-theme='dark']) .footer-socials img {
   width: 150px !important;
 }
 
+/* Plain GitHub icon-link (octocat, no star count). Hidden on wide screens where
+   the star button above is shown; swapped in at narrow/mobile widths below. */
+.navbar-github-icon {
+  display: none;
+}
+.navbar-github-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 8px;
+  color: var(--ifm-navbar-link-color);
+  border-radius: 6px;
+  transition: background-color 0.2s ease;
+}
+.navbar-github-button:hover {
+  background-color: #f0f0f0;
+  color: var(--ifm-navbar-link-hover-color);
+}
+[data-theme='dark'] .navbar-github-button:hover {
+  background-color: #1a1a1a;
+}
+
 /* Navbar Slack button */
 .navbar-slack-button {
   display: inline-flex;
@@ -650,29 +671,54 @@ html:not([data-theme='dark']) .footer-socials img {
   background-color: #1a1a1a;
 }
 
-@media screen and (max-width: 700px) {
-  .navbar__inner .navbar-github-stars {
-    display: none !important;
-  }
-  /* Hide the Slack icon in the header on mobile to avoid overlapping the
-     logo; it remains available in the collapsed (hamburger) menu. */
-  .navbar__inner .navbar-slack-item {
-    display: none !important;
-  }
-}
-
 @media screen and (max-width: 996px) {
   /* Reserve space for the absolutely-positioned search bar (144px + 16px = 160px) */
   .navbar__items--right {
     padding-right: 164px !important;
   }
-  /* Compact GitHub iframe so both items fit before search overlay */
-  .navbar-github-stars iframe {
-    width: 80px !important;
+  /* Swap the star button for the plain GitHub icon (no count) at narrow widths;
+     keep it (and the Slack icon) in the header down through mobile. */
+  .navbar-github-stars {
+    display: none !important;
+  }
+  .navbar-github-icon {
+    display: flex !important;
   }
   /* Slack icon only — hide text label */
   .slack-label {
     display: none !important;
+  }
+}
+
+/* ===== Narrow-desktop navbar (997px–1200px) =====
+   Above Docusaurus's 996px hamburger breakpoint the full navbar stays inline,
+   but the left group (…version dropdown) and right group (GitHub star…) don't
+   fit and overlap under justify-content: space-between — the logo runs into
+   "Documentation" and the version dropdown runs into the GitHub star. Compact
+   the widest items so the row fits without prematurely raising the (JS-gated)
+   996px mobile breakpoint. */
+@media screen and (min-width: 997px) and (max-width: 1200px) {
+  /* Tighter inter-item spacing for the left links */
+  .navbar__item.navbar__link,
+  .navbar__items--left > .navbar__link {
+    padding-left: 0.4rem;
+    padding-right: 0.4rem;
+  }
+  /* Drop the fixed 10rem/9rem version-dropdown reservation; size to content */
+  .navbar__items--left > .dropdown,
+  .navbar__items--left > .navbar__item.dropdown {
+    min-width: 0;
+  }
+  .navbar__items--left > .dropdown > .navbar__link {
+    min-width: 0;
+  }
+  /* Slack: icon only (full label returns at wider widths) */
+  .navbar-slack-button .slack-label {
+    display: none;
+  }
+  /* Compact the GitHub star button */
+  .navbar-github-stars iframe {
+    width: 90px !important;
   }
 }
 


### PR DESCRIPTION
## Problem
At **997–1200px** the navbar stays in desktop mode (Docusaurus only collapses to the hamburger at ≤996px), but the left group (…version dropdown) and right group (GitHub star…) don't fit and overlap under `justify-content: space-between` — the **logo runs into "Documentation"** and the **version dropdown runs into the GitHub star**. Separately, the GitHub star and Slack icon were hidden entirely at ≤700px.

## Fix
- **997–1200px media query** that compacts the widest items so the row fits without raising the JS-gated 996px mobile breakpoint (which would break the hamburger toggle): version dropdown → content width, Slack → icon-only, compact GitHub star, tighter link padding.
- **Plain GitHub octocat icon** (no star count) that replaces the star button at ≤996px, and **keep both the GitHub and Slack icons in the header down through mobile** (previously hidden at ≤700px).

Applied to both navbars — docs (`preview/`) and main site (root).

## Files
- `preview/src/css/custom.css`, `src/css/custom.css` — responsive navbar CSS
- `preview/docusaurus.config.ts`, `docusaurus.config.js` — GitHub octocat icon item

## Verified (Chrome at exact widths, both apps)
| Width | Result |
|---|---|
| 360 / 600 / 996px | GitHub octocat + Slack icons in header, **no overlap** |
| 997 / 1001 / 1200px | compact Star + Slack, logo clear of "Documentation" |
| ≥1201px | full Star button + "Join Slack" label |
| ≤996px | hamburger unchanged |

`build:all` + `check-links` pass (propagates to all versioned navbars).