### PR TITLE
Fixes version dropdown navigation from non-docs pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -156,6 +156,8 @@ const config = {
       },
     ],
 
+    require.resolve("./plugins/versions-plugin"),
+
     // Examples:
     // ['@docusaurus/plugin-google-analytics', { trackingID: 'UA-XXXXXX-X' }],
     // ['docusaurus-plugin-sass', {}],
@@ -226,19 +228,11 @@ const config = {
             position: "left",
             label: "Community",
           },
-          // Version dropdown — use a raw-HTML dropdown so the links inside cannot be
-          // intercepted by the SPA router. (A `type: 'dropdown'` with href items still
-          // gets wrapped by NavbarNavLink and SPA-navigates to a non-existent /docs/* route.)
+          // Version dropdown uses plain <a href> links (not SPA router) so navigation
+          // from /blog or /community → /docs forces a real page load.
           {
-            type: 'html',
+            type: 'custom-version-dropdown',
             position: 'left',
-            value: `<div class="navbar__item dropdown dropdown--hoverable">
-              <a class="navbar__link" href="#" aria-haspopup="true" onclick="return false">v0.7.0 (latest)</a>
-              <ul class="dropdown__menu">
-                <li><a class="dropdown__link" href="/docs/getting-started">v0.7.0 (latest)</a></li>
-                <li><a class="dropdown__link" href="/docs/dev/getting-started">Dev</a></li>
-              </ul>
-            </div>`,
           },
           {
             type: "html",

--- a/plugins/versions-plugin.js
+++ b/plugins/versions-plugin.js
@@ -59,7 +59,11 @@ module.exports = function versionsPlugin() {
           if (!byMinor[minor] || semverGT(tag, byMinor[minor])) byMinor[minor] = tag;
         }
 
-        const versions = Object.values(byMinor).sort().reverse();
+        const versions = Object.values(byMinor).sort((a, b) => {
+          if (semverGT(a, b)) return -1;
+          if (semverGT(b, a)) return 1;
+          return 0;
+        });
         fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
         fs.writeFileSync(OUTPUT, JSON.stringify(versions, null, 2));
         console.log(`[versions-plugin] Fetched and cached ${versions.length} versions from GitHub`);

--- a/plugins/versions-plugin.js
+++ b/plugins/versions-plugin.js
@@ -1,0 +1,76 @@
+// Build-time plugin: loads release tags and exposes them to the navbar component.
+
+const fs = require('fs');
+const path = require('path');
+
+const OUTPUT = path.join(__dirname, '..', 'static', 'releases.json');
+const PREVIEW_OUTPUT = path.join(__dirname, '..', 'preview', 'static', 'releases.json');
+
+const REPO = 'llm-d/llm-d';
+
+module.exports = function versionsPlugin() {
+  return {
+    name: 'llmd-versions-plugin',
+    async loadContent() {
+      for (const file of [OUTPUT, PREVIEW_OUTPUT]) {
+        if (fs.existsSync(file)) {
+          try {
+            const versions = JSON.parse(fs.readFileSync(file, 'utf-8'));
+            console.log(`[versions-plugin] Loaded ${versions.length} versions from ${file}`);
+            return versions;
+          } catch (e) {
+            console.warn(`[versions-plugin] Failed to parse ${file}: ${e.message}`);
+          }
+        }
+      }
+
+      console.log('[versions-plugin] No local releases.json found, fetching from GitHub...');
+      try {
+        const resp = await fetch(
+          `https://api.github.com/repos/${REPO}/tags?per_page=100`,
+          {
+            headers: process.env.GITHUB_TOKEN
+              ? { Authorization: `token ${process.env.GITHUB_TOKEN}` }
+              : {},
+          }
+        );
+        if (!resp.ok) throw new Error(`GitHub API: ${resp.status}`);
+        const tags = await resp.json();
+
+        const stable = tags
+          .map((t) => t.name)
+          .filter((n) => /^v\d+\.\d+(\.\d+)?$/.test(n));
+
+        const semverGT = (a, b) => {
+          const pa = a.replace(/^v/, '').split('.').map(Number);
+          const pb = b.replace(/^v/, '').split('.').map(Number);
+          for (let i = 0; i < 3; i++) {
+            if ((pa[i] || 0) > (pb[i] || 0)) return true;
+            if ((pa[i] || 0) < (pb[i] || 0)) return false;
+          }
+          return false;
+        };
+
+        const byMinor = {};
+        for (const tag of stable) {
+          const m = tag.match(/^v(\d+\.\d+)/);
+          if (!m) continue;
+          const minor = m[1];
+          if (!byMinor[minor] || semverGT(tag, byMinor[minor])) byMinor[minor] = tag;
+        }
+
+        const versions = Object.values(byMinor).sort().reverse();
+        fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+        fs.writeFileSync(OUTPUT, JSON.stringify(versions, null, 2));
+        console.log(`[versions-plugin] Fetched and cached ${versions.length} versions from GitHub`);
+        return versions;
+      } catch (e) {
+        console.warn(`[versions-plugin] GitHub fetch failed: ${e.message}`);
+        return [];
+      }
+    },
+    async contentLoaded({ content, actions }) {
+      actions.setGlobalData({ releases: content });
+    },
+  };
+};

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -40,6 +40,8 @@ echo ""
 # Step 1: Build main site (landing, blog, community)
 echo "Step 1: Building main site..."
 cd "$PROJECT_DIR"
+# Keep the main-site version dropdown in sync with the docs build.
+cp -f preview/static/releases.json static/releases.json 2>/dev/null || true
 npm run build
 echo "✓ Main site built to build/"
 echo ""

--- a/src/components/VersionDropdown.jsx
+++ b/src/components/VersionDropdown.jsx
@@ -107,7 +107,12 @@ export default function VersionDropdown() {
 
   return (
     <div className="navbar__item dropdown dropdown--hoverable">
-      <a className="navbar__link" href="#" onClick={(e) => e.preventDefault()}>
+      <a
+        className="navbar__link"
+        href="#"
+        aria-haspopup="true"
+        aria-label="Documentation version"
+        onClick={(e) => e.preventDefault()}>
         {getDropdownLabel()}
       </a>
       <ul className="dropdown__menu">

--- a/src/components/VersionDropdown.jsx
+++ b/src/components/VersionDropdown.jsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import {usePluginData} from '@docusaurus/useGlobalData';
+import {useLocation} from '@docusaurus/router';
+
+const REPO_URL = 'https://github.com/llm-d/llm-d/tree';
+const MIN_WEBSITE_VERSION = '0.7.0';
+const DEV_VERSION = 'dev';
+
+function isVersionGTE(version, target) {
+  const parseVersion = (v) => {
+    const stripped = v.replace(/^v/, '');
+    return stripped.split('.').map((n) => parseInt(n, 10));
+  };
+
+  const [v1, v2] = [parseVersion(version), parseVersion(target)];
+
+  for (let i = 0; i < 3; i++) {
+    if ((v1[i] || 0) > (v2[i] || 0)) return true;
+    if ((v1[i] || 0) < (v2[i] || 0)) return false;
+  }
+  return true;
+}
+
+export default function VersionDropdown() {
+  const pluginData = usePluginData('llmd-versions-plugin');
+
+  const location = useLocation();
+  const [releases, setReleases] = React.useState(pluginData?.releases || []);
+
+  const getFullPath = () =>
+    typeof window !== 'undefined' ? window.location.pathname : location.pathname;
+
+  React.useEffect(() => {
+    if (!pluginData?.releases || pluginData.releases.length === 0) {
+      const base = typeof window !== 'undefined' ? window.location.origin : '';
+      fetch(`${base}/docs/releases.json`)
+        .then((res) => res.json())
+        .then((data) => {
+          if (Array.isArray(data) && data.every((v) => typeof v === 'string')) {
+            setReleases(data);
+          } else {
+            console.warn('[VersionDropdown] Invalid releases.json format, expected array of strings');
+          }
+        })
+        .catch((err) => console.warn('[VersionDropdown] Failed to load releases.json:', err));
+    }
+  }, [pluginData]);
+
+  const latestTag = releases?.[0];
+  const latestVersion = latestTag?.replace(/^v/, '');
+  const olderReleases = (releases?.slice(1) || []).filter((tag) =>
+    isVersionGTE(tag.replace(/^v/, ''), MIN_WEBSITE_VERSION),
+  );
+
+  const getCurrentVersion = () => {
+    const path = getFullPath();
+
+    if (/^\/docs\/dev(\/|$)/.test(path)) return DEV_VERSION;
+
+    let match = path.match(/^\/docs\/(\d+\.\d+(?:\.\d+)?)\//);
+    if (match) return match[1];
+
+    if (/^\/dev(\/|$)/.test(path)) return DEV_VERSION;
+    match = path.match(/^\/(\d+\.\d+(?:\.\d+)?)\//);
+    if (match) return match[1];
+
+    return latestVersion || null;
+  };
+
+  const currentVersion = getCurrentVersion();
+
+  const getVersionUrl = (tag) => {
+    const version = tag.replace(/^v/, '');
+
+    if (latestTag && tag === latestTag) {
+      return '/docs/getting-started';
+    }
+    if (isVersionGTE(version, MIN_WEBSITE_VERSION)) {
+      return `/docs/${version}/getting-started`;
+    }
+    return `${REPO_URL}/${tag}/docs`;
+  };
+
+  const getDevUrl = () =>
+    latestTag ? '/docs/dev/getting-started' : '/docs/getting-started';
+
+  const isExternalLink = (tag) => {
+    const version = tag.replace(/^v/, '');
+    return !isVersionGTE(version, MIN_WEBSITE_VERSION);
+  };
+
+  const getDropdownLabel = () => {
+    if (currentVersion === DEV_VERSION) return 'dev';
+    if (!currentVersion) return latestTag ? `${latestTag} (latest)` : 'dev';
+
+    const vTag = `v${currentVersion}`;
+    if (vTag === latestTag) return `${vTag} (latest)`;
+    return vTag;
+  };
+
+  const isDevActive = currentVersion === DEV_VERSION;
+  const isLatestActive =
+    !!latestTag &&
+    !!currentVersion &&
+    currentVersion !== DEV_VERSION &&
+    `v${currentVersion}` === latestTag;
+
+  return (
+    <div className="navbar__item dropdown dropdown--hoverable">
+      <a className="navbar__link" href="#" onClick={(e) => e.preventDefault()}>
+        {getDropdownLabel()}
+      </a>
+      <ul className="dropdown__menu">
+        <li>
+          <a
+            className={`dropdown__link ${isDevActive ? 'dropdown__link--active' : ''}`}
+            href={getDevUrl()}>
+            dev
+          </a>
+        </li>
+        {latestTag && (
+          <>
+            <li
+              className="dropdown-separator"
+              style={{
+                borderTop: '1px solid rgba(255,255,255,0.1)',
+                margin: '0.25rem 0',
+              }}
+            />
+            <li>
+              <a
+                className={`dropdown__link ${isLatestActive ? 'dropdown__link--active' : ''}`}
+                href={getVersionUrl(latestTag)}
+                {...(isExternalLink(latestTag) && {
+                  target: '_blank',
+                  rel: 'noopener noreferrer',
+                })}>
+                latest ({latestTag}){isExternalLink(latestTag) ? ' →' : ''}
+              </a>
+            </li>
+          </>
+        )}
+        {olderReleases.length > 0 &&
+          olderReleases.map((tag) => (
+            <li key={tag}>
+              <a
+                className={`dropdown__link ${currentVersion && currentVersion !== DEV_VERSION && `v${currentVersion}` === tag ? 'dropdown__link--active' : ''}`}
+                href={getVersionUrl(tag)}
+                {...(isExternalLink(tag) && {
+                  target: '_blank',
+                  rel: 'noopener noreferrer',
+                })}>
+                {tag}
+                {isExternalLink(tag) ? ' →' : ''}
+              </a>
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/theme/NavbarItem/ComponentTypes.js
+++ b/src/theme/NavbarItem/ComponentTypes.js
@@ -1,0 +1,7 @@
+import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import VersionDropdown from '@site/src/components/VersionDropdown';
+
+export default {
+  ...ComponentTypes,
+  'custom-version-dropdown': VersionDropdown,
+};


### PR DESCRIPTION
## What does this PR do?

-   Replaces the static HTML version dropdown in the navbar with a dynamic React component (`VersionDropdown.jsx`).
-   Introduces a new Docusaurus plugin (`versions-plugin.js`) that fetches and caches repository release tags from GitHub's API at build time.
-   The new `VersionDropdown` component utilizes this fetched data to dynamically generate and display links for "dev", "latest", and older stable release documentation.
-   Updates the Docusaurus configuration to integrate the new versions plugin and to use the custom React component for the navbar's version dropdown.
-   Modifies the `build-all.sh` script to copy the generated `releases.json` to the main static directory, ensuring the main site has access to the version data.

## Why is this change needed?

The previous raw HTML version dropdown in the navbar was causing navigation issues, particularly when attempting to switch documentation versions from non-documentation pages such as blog posts or community pages. This change ensures that the version dropdown functions correctly across all sections of the site, providing seamless navigation to the desired documentation version. It also automates the process of populating the dropdown with current release information, reducing manual updates.

## How was this tested?

-   [ ] Tests added/updated (`npm test`)
-   [x] Site builds successfully (`npm run build:all`)
-   [ ] Check links after buildling (`npm run check-links`)
-   [x] Manual testing performed (`npm run serve`)

## Checklist

-   [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
-   [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
-   [x] Tests pass locally (`npm test`)
-   [x] Site builds without errors (`npm run build:all`)
-   [ ] No broken links after building full site (`npm run check-links`)
-   [ ] Documentation updated (if applicable)

## Related Issues