### PR TITLE
Update slack invite URL for /slack endpoint

### DIFF
--- a/static/slack/index.html
+++ b/static/slack/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="refresh" content="2; url=https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw">
-    <link rel="canonical" href="https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw">
+    <meta http-equiv="refresh" content="2; url=https://join.slack.com/t/llm-d/shared_invite/zt-43t0hj2dc-Le_GtjBT6jF9bs_AMvgr9Q">
+    <link rel="canonical" href="https://join.slack.com/t/llm-d/shared_invite/zt-43t0hj2dc-Le_GtjBT6jF9bs_AMvgr9Q">
     
     <!-- Page title and meta information -->
     <title>Redirecting to llm-d Slack Community</title>
@@ -15,7 +15,7 @@
     <meta property="og:title" content="Join llm-d Slack Community">
     <meta property="og:description" content="Join the llm-d community on Slack">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw">
+    <meta property="og:url" content="https://join.slack.com/t/llm-d/shared_invite/zt-43t0hj2dc-Le_GtjBT6jF9bs_AMvgr9Q">
     
     <!-- Twitter Card tags -->
     <meta name="twitter:card" content="summary">
@@ -105,7 +105,7 @@
         </div>
         
         <p>
-            <a href="https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw" id="fallback-link" class="redirect-link">
+            <a href="https://join.slack.com/t/llm-d/shared_invite/zt-43t0hj2dc-Le_GtjBT6jF9bs_AMvgr9Q" id="fallback-link" class="redirect-link">
                 Click here if you are not redirected automatically
             </a>
         </p>
@@ -114,14 +114,14 @@
             <p><strong>If the redirect doesn't work:</strong></p>
             <p>Please copy and paste this URL into your browser:</p>
             <p id="manual-url" style="word-break: break-all; font-family: monospace; background: #f8f9fa; padding: 10px; border-radius: 4px;">
-                https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw
+                https://join.slack.com/t/llm-d/shared_invite/zt-43t0hj2dc-Le_GtjBT6jF9bs_AMvgr9Q
             </p>
         </div>
     </div>
 
     <!-- Progressive enhancement: countdown timer and JS redirect -->
     <script>
-        var REDIRECT_URL = 'https://join.slack.com/t/llm-d/shared_invite/zt-3vjxmypf9-63gI5wHRhn6D60zzad67Bw';
+        var REDIRECT_URL = 'https://join.slack.com/t/llm-d/shared_invite/zt-43t0hj2dc-Le_GtjBT6jF9bs_AMvgr9Q';
         let timeLeft = 2;
         const countdownElement = document.getElementById('countdown');
         const messageElement = document.getElementById('redirect-message');


### PR DESCRIPTION
## What does this PR do?

Updates the slack invite link on the llm-d.ai/slack

## Why is this change needed?

For some reason we can't use tools like community inviter or inviter.co anymore as the slack organization has sent too many invites out that have not been accepted.  Because of that we need to update the invite URL every 400 invites, my hope this gets resolved when we moved back to a paid status. 

