### PR TITLE
Ensure footer aligns between docs pages and "main site"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -262,9 +262,6 @@ const config = {
       // Config for footer here
       footer: {
         style: "dark",
-        copyright: `Copyright llm-d a Series of LF Projects, LLC. Apache 2.0 License.<br />\
-        We are a Cloud Native Computing Foundation sandbox project.<br />\
-        For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/" target="_blank" rel="noreferrer noopener">https://lfprojects.org/policies/</a>`,
         logo: {
           alt: "llm-d Logo",
           src: "img/cncf-white.png",
@@ -295,16 +292,13 @@ const config = {
             title: "Community",
             items: [
               {
-                label: "Contact us",
-                href: "/community",
+                html: '<a href="/community" class="footer__link-item">Contact us</a>',
               },
               {
-                label: "Contributing",
-                href: "/community/contribute",
+                html: '<a href="/community/contribute" class="footer__link-item">Contributing</a>',
               },
               {
-                label: "Code of Conduct",
-                href: "/community/code-of-conduct",
+                html: '<a href="/community/code-of-conduct" class="footer__link-item">Code of Conduct</a>',
               },
             ],
           },
@@ -312,8 +306,7 @@ const config = {
             title: "More",
             items: [
               {
-                label: "Blog",
-                to: "/blog",
+                html: '<a href="/blog" class="footer__link-item">Blog</a>',
               },
               {
                 label: "Privacy Policy",
@@ -365,7 +358,9 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright llm-d a Series of LF Projects, LLC. Apache 2.0 License.`,
+        copyright: `Copyright llm-d a Series of LF Projects, LLC. Apache 2.0 License.<br />\
+        We are a Cloud Native Computing Foundation sandbox project.<br />\
+        For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/" target="_blank" rel="noreferrer noopener">https://lfprojects.org/policies/</a>`,
       },
       prism: {
         theme: prismThemes.vsLight,

--- a/preview/docusaurus.config.ts
+++ b/preview/docusaurus.config.ts
@@ -400,7 +400,7 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} llm-d project. Apache 2.0 License.<br />\
+      copyright: `Copyright llm-d a Series of LF Projects, LLC. Apache 2.0 License.<br />\
         We are a Cloud Native Computing Foundation sandbox project.<br />\
         For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/" target="_blank" rel="noreferrer noopener">https://lfprojects.org/policies/</a>`,
       logo: {


### PR DESCRIPTION
## What does this PR do?

Looking at the footers between https://llm-d.ai/docs/getting-started and https://llm-d.ai/community were different.  This is from the issue where we have technically 2 docusaurus sites from the big docs site work.  


## Why is this change needed?

This change should align things so footers look the same everywhere

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build:all`)
- [x] Check links after buildling (`npm run check-links`)
- [x] Manual testing performed (`npm run serve`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build:all`)
- [x] No broken links after building full site (`npm run check-links`)
- [x] Documentation updated (if applicable)

