### PR TITLE
Fix slug collision for getting-started documentation in sync-docs.sh

### DIFF
--- a/preview/scripts/sync-docs.sh
+++ b/preview/scripts/sync-docs.sh
@@ -125,6 +125,14 @@ if [[ -f "$WIP/getting-started/README.mdx" ]]; then
 else
   cp_doc "$WIP/getting-started/README.md"     "$DOCS_DIR/getting-started/index.md"
 fi
+# Upstream's README.mdx sets `slug: /`, claiming this site's root route. But
+# src/pages/index.tsx already owns "/" everywhere (a <Redirect> to
+# /getting-started, baseUrl-aware), so the two collide and "/" ends up
+# rendering neither — an empty, unhydratable shell in every build. Force
+# this doc back to its natural /getting-started slug so the pages-plugin
+# homepage redirect keeps working as designed.
+set_doc_slug "$DOCS_DIR/getting-started/index.mdx" "/getting-started"
+set_doc_slug "$DOCS_DIR/getting-started/index.md" "/getting-started"
 cp_doc "$WIP/getting-started/quickstart.md"   "$DOCS_DIR/getting-started/quickstart.md"
 cp_doc "$WIP/getting-started/feature-matrix.md" "$DOCS_DIR/getting-started/feature-matrix.md"
 cp_doc "$WIP/getting-started/accelerators.md" "$DOCS_DIR/getting-started/accelerators.md"


### PR DESCRIPTION
## What does this PR do?

Ensure the getting-started documentation correctly uses the slug "/getting-started" to avoid rendering issues with the homepage redirect. This change aligns the documentation structure with the existing routing logic in the application.

Root cause: src/pages/index.tsx has always handled the site root / via <Redirect to={useBaseUrl('/getting-started')} /> for every build (dev, stable, versioned) — / intentionally has no real content, it just bounces to /getting-started. Upstream's getting-started/README.mdx (synced from llm-d/llm-d) sets slug: / in its frontmatter, which claims that same root route. The collision leaves / rendering as an empty, unhydratable shell, and the intended /getting-started page (with its real content) never gets built at its normal path.

Fix: In preview/scripts/sync-docs.sh, force the synced doc's slug back to /getting-started (via the existing set_doc_slug helper, same pattern already used for other upstream slug overrides) right after it's copied, instead of accepting upstream's slug: /. This restores the pre-existing, working design where / redirects to /getting-started rather than colliding with it.


## How was this tested?

- [x] Site builds successfully (`npm run build:all`)
- [x] Manual testing performed (`npm run serve`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build:all`)
- [x] No broken links after building full site (`npm run check-links`)
- [x] Documentation updated (if applicable)
