### PR TITLE
Fix(landing): remove oversized gap above footer on mobile

### DIFF
--- a/src/landing/Frame156.tsx
+++ b/src/landing/Frame156.tsx
@@ -2781,7 +2781,7 @@ function Frame105() {
 function Frame85() {
   return (
     <div className="col-1 justify-self-stretch relative row-4 self-stretch shrink-0">
-      <div className="content-stretch flex flex-col gap-[48px] items-start py-[88px] relative size-full">
+      <div className="llmd-community-section content-stretch flex flex-col gap-[48px] items-start py-[88px] relative size-full">
         <Frame86 />
         <Frame105 />
       </div>

--- a/src/landing/landing.css
+++ b/src/landing/landing.css
@@ -231,6 +231,12 @@ html[data-theme='dark'] .llmd-frame .llmd-release-option:hover {
 /* Column back into flow at full width — overrides the absolute/centered desktop
    rules and the design's hardcoded 922px widths (content column, section copy,
    release panel). */
+/* With the column back in flow the frame auto-heights to its content, so drop
+   the desktop `min-height: 4400px` pre-hydration fallback — otherwise it leaves
+   a tall empty band between the last section and the footer on mobile. */
+.llmd-frame.llmd-mobile {
+  min-height: 0;
+}
 .llmd-frame.llmd-mobile .llmd-content {
   position: relative;
   left: 0;
@@ -260,6 +266,13 @@ html[data-theme='dark'] .llmd-frame .llmd-release-option:hover {
   box-sizing: border-box;
   padding-left: clamp(20px, 5vw, 56px);
   padding-right: clamp(20px, 5vw, 56px);
+}
+
+/* "Join the community" is the last section before the footer. Its full 88px
+   bottom padding leaves an oversized empty gap above the footer on mobile;
+   tighten it so the footer follows closely. Desktop keeps the 88px rhythm. */
+.llmd-frame.llmd-mobile .llmd-community-section {
+  padding-bottom: 32px;
 }
 
 /* --- Card grids: 4-across flex rows become 2-wide grids ------------------ */


### PR DESCRIPTION
## What does this PR do?

Removes an oversized empty gap between the **Join the community** section and the site footer on mobile / narrow viewports (< 940px).

Two changes in `src/landing/`:
- **`landing.css`** — adds `.llmd-frame.llmd-mobile { min-height: 0 }` so the landing frame hugs its content on mobile, and trims the community section's bottom padding (`88px → 32px`) via a new `.llmd-community-section` hook.
- **`Frame156.tsx`** — adds the `llmd-community-section` hook class to the community section wrapper (same convention as the existing `llmd-hero-section` / `llmd-after-hero` hooks).

## Why is this change needed?

On mobile the landing column is returned to normal flow (`.llmd-mobile`), so the `.llmd-frame` wrapper auto-heights to its content. The desktop pre-hydration fallback `min-height: 4400px` still applied, pinning the frame taller than its content and leaving a large empty band between the last section and the footer. Trimming the section padding alone had no visible effect, because the frame's forced height — not the padding — controlled where the footer landed.

## How was this tested?

Measured the computed layout with Chrome DevTools (CDP) at mobile (390px) and desktop (1280px) widths:

- **Mobile:** footer top moved from `y=4537` → `y=4309` — the ~228px dead band is gone; the footer now follows the community section directly.
- **Desktop (≥ 940px):** unchanged — the frame keeps its measured `min-height` and the section keeps `padding-bottom: 88px` (the min-height override and padding trim are both gated on `.llmd-mobile`).

- [ ] Tests added/updated (`npm test`) — N/A (presentational CSS change; no unit-test harness for landing layout)
- [x] Site builds successfully (`npm run build:all`) — clean build; the only warnings are pre-existing broken anchors in the upstream-synced docs, unrelated to this change
- [ ] Check links after building (`npm run check-links`) — unaffected (no links changed); covered by CI
- [x] Manual testing performed (dev server + DevTools layout measurement across viewport widths)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [ ] Tests pass locally (`npm test`) — N/A
- [x] Site builds without errors (`npm run build:all`)
- [ ] No broken links after building full site (`npm run check-links`) — no links changed; covered by CI
- [x] Documentation updated (if applicable) — N/A

## Related Issues

<!-- none -->
