### PR TITLE
Fix model server deployment command in quickstart.md

### DIFF
--- a/versioned_docs/version-0.8/getting-started/quickstart.md
+++ b/versioned_docs/version-0.8/getting-started/quickstart.md
@@ -64,7 +64,7 @@ helm install ${GUIDE_NAME} \
 Deploy the default model server (vLLM running on NVIDIA GPUs). This will deploy 8 replicas of `Qwen/Qwen3-32B` by default.
 
 ```bash
-kubectl apply -n ${NAMESPACE} -k guides/optimized-baseline/modelserver/gpu/vllm/
+kubectl apply -n ${NAMESPACE} -k guides/optimized-baseline/modelserver/gpu/vllm/base/
 ```
 
 :::tip


### PR DESCRIPTION
Updated the deployment command for the model server to point to the correct base directory.

## What does this PR do?

Corrects path in quickstart guide

## Why is this change needed?

I suspect the existing path used to work but now it does not.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [ ] Site builds successfully (`npm run build:all`)
- [ ] Check links after buildling (`npm run check-links`)
- [X] Manual testing performed (`npm run serve`)

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [X] Tests pass locally (`npm test`)
- [X] Site builds without errors (`npm run build:all`)
- [X] No broken links after building full site (`npm run check-links`)
- [X] Documentation updated (if applicable)

## Related Issues

N/A
