### PR TITLE
fix: point /slack redirect at non-expiring invite link

### DIFF
--- a/src/pages/slack.js
+++ b/src/pages/slack.js
@@ -5,8 +5,7 @@ import Link from '@docusaurus/Link';
 // /slack — host-agnostic redirect to the llm-d Slack invite (replaces the
 // upstream Netlify redirect so it also works under `docusaurus serve` and
 // any other host).
-const SLACK_INVITE =
-  'https://join.slack.com/t/llm-d/shared_invite/zt-44lb4d8o4-uFFmE9ZOyJIOy6lkiMUf6Q';
+const SLACK_INVITE = 'https://inviter.co/llm-d-slack';
 
 export default function Slack() {
   useEffect(() => {


### PR DESCRIPTION


## What does this PR do?

- Slack shared_invite links expire, so the /slack redirect and the community page 'Join Slack' button eventually land on a dead invite.

## Why is this change needed?
new users cannot join slack

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Tests added/updated (`npm test`)
- [ ] Site builds successfully (`npm run build:all`)
- [ ] Check links after buildling (`npm run check-links`)
- [ ] Manual testing performed (`npm run serve`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [ ] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build:all`)
- [x] No broken links after building full site (`npm run check-links`)
- [ ] Documentation updated (if applicable)

## Related Issues

fix: https://github.com/llm-d/llm-d/issues/2089
