### PR TITLE
Update slack URL to one with longer expiration

### DIFF
--- a/src/pages/slack.js
+++ b/src/pages/slack.js
@@ -6,7 +6,7 @@ import Link from '@docusaurus/Link';
 // upstream Netlify redirect so it also works under `docusaurus serve` and
 // any other host).
 const SLACK_INVITE =
-  'https://join.slack.com/t/llm-d/shared_invite/zt-44lb4d8o4-uFFmE9ZOyJIOy6lkiMUf6Q';
+  'https://join.slack.com/t/llm-d/shared_invite/zt-43t0hj2dc-Le_GtjBT6jF9bs_AMvgr9Q';
 
 export default function Slack() {
   useEffect(() => {


### PR DESCRIPTION
## What does this PR do?

Updates slack URL to an invite URL with a multi-year expiration (still limited to 400 invites)

## Why is this change needed?

when we did our large merge of the website - i had updated the url of the slack invite, but the code changed and that conflict must have got dropped. So basically when we deployed the new site, the old expired slack link got put back in place.

So then it looks like @jjasghar pushed a quick fix here https://github.com/llm-d/llm-d.github.io/pull/437 - BUT that invite has a 30 day expiration. I'll open another PR with the previous "correct" one that got merged over that has a longer life. /cc @davidgs

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Tests added/updated (`npm test`)
- [x] Site builds successfully (`npm run build:all`)
- [x] Check links after buildling (`npm run check-links`)
- [x] Manual testing performed (`npm run serve`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build:all`)
- [x] No broken links after building full site (`npm run check-links`)
- [x] Documentation updated (if applicable)

## Related Issues

https://github.com/llm-d/llm-d.github.io/pull/451
https://github.com/llm-d/llm-d.github.io/pull/437