### PR TITLE
fix: add bluesky domain verification back

### DIFF
--- a/static/.well-known/atproto-did
+++ b/static/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:7hkcdcz6qdtr6ozofulhtlb5


### PR DESCRIPTION
## What does this PR do?

For our bluesky account (https://bsky.app/profile/llm-d.ai) to work we need this to verify the domain.

## Why is this change needed?

In the recent website work this file was lost and its no longer available at https://llm-d.ai/.well-known/atproto-did - this makes our bluesky profile invalid and our automated metrics fail. 

## How was this tested?

- [x] Site builds successfully (`npm run build:all`)
- [x] Check links after buildling (`npm run check-links`)
- [x] Manual testing performed (`npm run serve`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build:all`)
- [x] No broken links after building full site (`npm run check-links`)
- [x] Documentation updated (if applicable)

