### PR TITLE
Adds automatic Bluesky posting for new blog posts

### DIFF
--- a/.github/workflows/rss-to-bluesky.yml
+++ b/.github/workflows/rss-to-bluesky.yml
@@ -36,7 +36,7 @@ jobs:
             echo "rss_url=$url"
           } >> "$GITHUB_ENV"
       - name: Post to Bluesky
-        uses: myConsciousness/bluesky-post@v5
+        uses: myConsciousness/bluesky-post@96827d0a9604cb228b11b3095f6961196efba4a0 # v5
         with:
           text: "${{ env.preview }}"
           link-preview-url: "${{ env.rss_url }}"

--- a/.github/workflows/rss-to-bluesky.yml
+++ b/.github/workflows/rss-to-bluesky.yml
@@ -12,10 +12,9 @@ jobs:
   fetch-and-post:
     runs-on: ubuntu-latest
     steps:
-      - name: Install xmllint and dateutils
+      - name: Install xmllint
         run: |
-          sudo apt-get update && sudo apt-get install -y libxml2-utils dateutils
-
+          sudo apt-get update && sudo apt-get install -y libxml2-utils
       - name: Fetch Latest Blog Post
         id: fetch_post
         run: |

--- a/.github/workflows/rss-to-bluesky.yml
+++ b/.github/workflows/rss-to-bluesky.yml
@@ -1,9 +1,12 @@
 name: Post Latest Blog from RSS to Bluesky
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
   schedule:
     - cron: '00 12 * * *'
+
+permissions:
+  contents: read
 
 jobs:
   fetch-and-post:

--- a/.github/workflows/rss-to-bluesky.yml
+++ b/.github/workflows/rss-to-bluesky.yml
@@ -1,0 +1,34 @@
+name: Post Latest Blog from RSS to Bluesky
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 12 * * *'
+
+jobs:
+  fetch-and-post:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install xmllint and dateutils
+        run: |
+          sudo apt-get update && sudo apt-get install -y libxml2-utils dateutils
+
+      - name: Fetch Latest Blog Post
+        id: fetch_post
+        run: |
+          RSS_FEED_URL="https://llm-d.ai/blog/rss.xml"
+          response=$(curl -s "$RSS_FEED_URL")
+          description=$(echo "$response" | xmllint --xpath "string(//item[1]/description)" -)
+          url=$(echo "$response" | xmllint --xpath "string(//item[1]/link)" -)
+          description=$(echo "$description" | xargs)
+          preview="$description $url"
+          echo "preview=$preview" >> $GITHUB_ENV
+          echo "rss_url=$url" >> $GITHUB_ENV
+
+      - name: Post to Bluesky
+        uses: myConsciousness/bluesky-post@v5
+        with:
+          text: "${{ env.preview }}"
+          link-preview-url: "${{ env.rss_url }}"
+          identifier: llm-d.ai.bsky.social
+          password: "${{ secrets.BSKY_SECRET }}"

--- a/.github/workflows/rss-to-bluesky.yml
+++ b/.github/workflows/rss-to-bluesky.yml
@@ -19,15 +19,23 @@ jobs:
       - name: Fetch Latest Blog Post
         id: fetch_post
         run: |
-          RSS_FEED_URL="https://llm-d.ai/blog/rss.xml"
-          response=$(curl -s "$RSS_FEED_URL")
-          description=$(echo "$response" | xmllint --xpath "string(//item[1]/description)" -)
-          url=$(echo "$response" | xmllint --xpath "string(//item[1]/link)" -)
-          description=$(echo "$description" | xargs)
-          preview="$description $url"
-          echo "preview=$preview" >> $GITHUB_ENV
-          echo "rss_url=$url" >> $GITHUB_ENV
+          set -euo pipefail
 
+          RSS_FEED_URL="https://llm-d.ai/blog/rss.xml"
+          response="$(curl -fsSL "$RSS_FEED_URL")"
+          description="$(printf '%s' "$response" | xmllint --xpath "string(//item[1]/description)" - | xargs)"
+          url="$(printf '%s' "$response" | xmllint --xpath "string(//item[1]/link)" - | xargs)"
+
+          if [ -z "$description" ] || [ -z "$url" ]; then
+            echo "Failed to parse latest post from RSS feed: $RSS_FEED_URL" >&2
+            exit 1
+          fi
+
+          preview="$description $url"
+          {
+            echo "preview=$preview"
+            echo "rss_url=$url"
+          } >> "$GITHUB_ENV"
       - name: Post to Bluesky
         uses: myConsciousness/bluesky-post@v5
         with:


### PR DESCRIPTION
## What does this PR do?

Implements a new GitHub Actions workflow (`rss-to-bluesky.yml`) to automate the sharing of the latest blog posts on Bluesky. This workflow is scheduled to run daily at 12:00 UTC and can also be triggered manually. It fetches the RSS feed, extracts the description and URL of the most recent post, and then publishes this information to a configured Bluesky account.

## Why is this change needed?

This change automates the promotion of new blog content on Bluesky, ensuring timely updates and increasing the visibility of published articles without requiring manual intervention. It streamlines the content distribution process for new blog posts.

## How was this tested?

- [ ] Tests added/updated (`npm test`)
- [ ] Site builds successfully (`npm run build:all`)
- [ ] Check links after buildling (`npm run check-links`)
- [x] Manual testing performed (`npm run serve`) - *Manual triggering of the GitHub Action workflow.*

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Site builds without errors (`npm run build:all`)
- [x] No broken links after building full site (`npm run check-links`)
- [x] Documentation updated (if applicable)

## Related Issues