### PR TITLE
[Blog] Clarify GLM-5.2 benchmark corpus

### DIFF
--- a/blog/2026-07-22_serving-glm-5-2-agentic-workloads-on-llm-d.mdx
+++ b/blog/2026-07-22_serving-glm-5-2-agentic-workloads-on-llm-d.mdx
@@ -127,7 +127,7 @@ Topology names describe the number and width of the serving instances. `xPyD` me
 
 ### What the performance results cover
 
-The performance tests use requests derived from the production traces, not the complete corpus unchanged. Limited-input-length runs admit requests below 142,000 tokens; full-input-length runs admit longer contexts. Corpus statistics describe the full production workload, while performance results describe the requests admitted by each test. Absolute throughput is comparable only within the same test.
+The workload analysis uses SemiAnalysis's 219-session [`cc-traces-weka-with-subagents-051926`](https://huggingface.co/datasets/semianalysisai/cc-traces-weka-with-subagents-051926) corpus. The performance tests use the 393-trace [`cc-traces-weka-062126`](https://huggingface.co/datasets/semianalysisai/cc-traces-weka-062126) release, which applies additional trace-quality filters. Limited-input-length runs admit traces that fit a 142,000-token context limit; full-input-length runs admit longer contexts. The workload statistics and performance results therefore cover different request populations. Absolute throughput is comparable only within the same test.
 
 :::note Deployment and benchmark details
 


### PR DESCRIPTION
## What changed

- name and link the SemiAnalysis corpus used for workload analysis
- name and link the separate corpus release used for performance tests
- clarify that the analysis and benchmark results cover different request populations

## Why

The post analyzes the 219-session `051926` corpus, while AIPerf benchmarks the 393-trace `062126` release. The benchmark-scope paragraph did not make that boundary explicit.

## Validation

- `npm run build`
- verified both Hugging Face links in the generated blog HTML

The build succeeds. It reports pre-existing broken-anchor warnings in unrelated documentation pages.