### PR TITLE
[Blog] Update Sticky Until Saturated post date to publication day

### DIFF
--- a/blog/2026-08-17_bottleneck-aware-scheduling-for-llm-inference.mdx
+++ b/blog/2026-08-17_bottleneck-aware-scheduling-for-llm-inference.mdx
@@ -2,7 +2,7 @@
 title: "Sticky Until Saturated: Token-Aware Routing in llm-d"
 description: "The llm-d router's default configuration is built on token-aware routing: keep each request on the cache-warm endpoint until a calibrated token-load limit is exceeded, then route by load alone, sustaining 2-3x round-robin throughput with the one required threshold derived from a single hardware calibration measurement."
 slug: bottleneck-aware-scheduling-for-llm-inference
-date: 2026-08-04T09:00
+date: 2026-08-17T09:00
 
 authors:
   - kaushikmitra


### PR DESCRIPTION
Follow-up to #462. Sets the post date to 2026-08-17 (publication day) and renames the file to match the repo's date-prefix convention. The URL is unchanged since the post sets an explicit slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)