### PR TITLE
[Blog] Rename Sticky Until Saturated post slug to match its title

### DIFF
--- a/blog/2026-08-17_sticky-until-saturated-token-aware-routing.mdx
+++ b/blog/2026-08-17_sticky-until-saturated-token-aware-routing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sticky Until Saturated: Token-Aware Routing in llm-d"
 description: "The llm-d router's default configuration is built on token-aware routing: keep each request on the cache-warm endpoint until a calibrated token-load limit is exceeded, then route by load alone, sustaining 2-3x round-robin throughput with the one required threshold derived from a single hardware calibration measurement."
-slug: bottleneck-aware-scheduling-for-llm-inference
+slug: sticky-until-saturated-token-aware-routing
 date: 2026-08-17T09:00
 
 authors:


### PR DESCRIPTION
Follow-up to #462 / #474. The post was retitled during review but kept its original slug, so the URL still said `bottleneck-aware-scheduling-for-llm-inference`. This renames the slug and filename to `sticky-until-saturated-token-aware-routing` so the URL matches the title.

New URL: https://llm-d.ai/blog/sticky-until-saturated-token-aware-routing

Note: the old URL is intentionally not redirected (the site has no redirects plugin configured); anyone holding the old link will get a 404 after this merges.
