### PR TITLE
blog: add GitHub icon to niliguy author profile

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -53,6 +53,7 @@ niliguy:
   image_url: /img/blogs/niliguy.webp
   socials:
     linkedin: nilig
+    github: nilig
 
 etailevran:
   name: Etai Lev Ran


### PR DESCRIPTION
## What does this PR do?

Adds `github: nilig` to the `niliguy` entry's `socials:` in `blog/authors.yml`, so the author profile renders a GitHub icon alongside the LinkedIn one.

## Why is this change needed?

The profile links GitHub only via the top-level `url:` field, which hyperlinks the name but renders no icon; Docusaurus draws social icons only from the `socials:` map. This landed on the #458 branch after that PR merged, so it is re-submitted from main.

## How was this tested?

- [ ] Tests added/updated (`npm test`)
- [ ] Site builds successfully (`npm run build:all`)
- [ ] Check links after buildling (`npm run check-links`)
- [ ] Manual testing performed (`npm run serve`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per DCO
- [x] Code follows project contributing guidelines