### PR TITLE
fix: restore kapa.ai AI assistant widget

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -95,6 +95,18 @@ const config = {
     },
   },
 
+  // Add kapa.ai AI assistant widget
+  scripts: [
+    {
+      src: 'https://widget.kapa.ai/kapa-widget.bundle.js',
+      'data-website-id': '1eea1a6a-a57b-48d7-a4aa-c993481daad7',
+      'data-project-name': 'llm-d',
+      'data-project-color': '#9b4d9b',
+      'data-project-logo': 'https://llm-d.ai/img/llm-d-favicon.png',
+      async: true,
+    },
+  ],
+
   presets: [
     [
       "classic",


### PR DESCRIPTION
## What does this PR do?

Re-adds the kapa.ai AI assistant widget script to `docusaurus.config.js` so the assistant returns to llm-d.ai.

## Why is this change needed?

The kapa.ai widget was originally added in #289 (merged 2026-05-14). It was dropped when `docusaurus.config.js` was rewritten from scratch in #421 ("New Build system and new docs architecture", merged 2026-07-17). That PR was a build-system + docs-architecture migration (Go `llmd-site` CLI, consolidated `/docs`, site relocated to repo root) and rebuilt the config wholesale — the `scripts:` block simply didn't carry over. Nothing in #421 indicates the widget was removed on purpose.

This restores the same widget configuration that #289 shipped.

## How was this tested?

- `node --check docusaurus.config.js` passes (valid syntax).
- Diff is scoped to the single re-added `scripts:` block; no other config changed.
- No pre-existing `scripts:` key, so no duplicate-key conflict.

## Checklist

- [x] Commits are signed off (`git commit -s`) per DCO

🤖 Generated with [Claude Code](https://claude.com/claude-code)