### PR TITLE
Fix v0.9 blog post date to Aug 28

### DIFF
--- a/blog/2026-08-28_llm-d-v0.9-hardened-for-scale.md
+++ b/blog/2026-08-28_llm-d-v0.9-hardened-for-scale.md
@@ -2,7 +2,7 @@
 title: "llm-d v0.9: Hardened for Scale"
 description: "llm-d v0.9 hardens the router for production scale with HA, KEDA-native autoscaling, and end-to-end observability — while expanding to diffusion models, GB200/GB300 hardware, and next-generation disaggregated inference."
 slug: llm-d-v0.9-hardened-for-scale
-date: 2026-08-13T09:00
+date: 2026-08-28T09:00
 
 authors:
   - llm-d-maintainers


### PR DESCRIPTION
Updates the v0.9 release blog post date from Aug 13 to Aug 28 and renames the file accordingly.

Follow-up to #472.